### PR TITLE
fix(sidebar): Ensure mobile sidebar navigation scrolls correctly

### DIFF
--- a/src/frontend/src/components/layout/Sidebar.tsx
+++ b/src/frontend/src/components/layout/Sidebar.tsx
@@ -51,7 +51,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isSidebarOpen }) => {
   return (
     <aside
       className={`
-        z-50                 /* sits above page */
+  flex flex-col z-50    /* sits above page */
         bg-card border-r p-4 
 
         /* DESKTOP (≥ md)  ----------------------------------- */


### PR DESCRIPTION
The sidebar's `aside` element was not a flex container, which prevented the child `nav` element (with `flex-grow`) from correctly calculating its height to fill available space. This meant that on mobile devices, if the list of navigation items was taller than the viewport, `overflow-y-auto` would not work as expected, hiding some items.

This commit adds `flex flex-col` to the `aside` element's Tailwind classes. This change makes the `aside` a vertical flex container, allowing the `nav` element to properly grow and its `overflow-y-auto` property to enable scrolling when the content exceeds the available height. This fixes the issue where you could not see all buttons in the sidebar menu on your phones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved sidebar layout by applying a vertical flex column arrangement for better structure and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->