### PR TITLE
fix(layout): Prevent sidebar scroll jump by optimizing resize handling

### DIFF
--- a/src/frontend/src/components/layout/Layout.tsx
+++ b/src/frontend/src/components/layout/Layout.tsx
@@ -14,10 +14,15 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     typeof window !== "undefined" && window.innerWidth < 768
   );
   useEffect(() => {
-    const onResize = () => setIsMobile(window.innerWidth < 768);
+    const onResize = () => {
+      const newMobileState = window.innerWidth < 768;
+      if (newMobileState !== isMobile) {
+        setIsMobile(newMobileState);
+      }
+    };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-  }, []);
+  }, [isMobile]);
 
   const toggleSidebar = () => {
     setIsSidebarOpen(!isSidebarOpen);

--- a/src/frontend/src/components/layout/Sidebar.tsx
+++ b/src/frontend/src/components/layout/Sidebar.tsx
@@ -59,7 +59,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isSidebarOpen }) => {
         ${isSidebarOpen ? "md:w-64" : "md:w-16"}
 
         /* MOBILE (< md)  ------------------------------------ */
-        fixed md:relative      h-screen md:h-auto
+  fixed top-0 left-0 md:relative h-dvh md:h-auto
         transition-transform duration-300 ease-in-out
         ${isSidebarOpen ? "translate-x-0" : "-translate-x-full"}
         w-64                   /* full drawer width on mobile */


### PR DESCRIPTION
The sidebar navigation menu on mobile devices was experiencing a "scroll jump to top" issue. This was caused by the main Layout component re-rendering too frequently in response to window resize events, even when the actual mobile/desktop breakpoint status didn't change. These re-renders would reset the scroll position of the sidebar's navigation area.

This commit refines the `useEffect` hook in `Layout.tsx` that handles window resizing:
1. The `onResize` handler now explicitly checks if the new mobile status (derived from `window.innerWidth`) is different from the current `isMobile` state.
2. `setIsMobile` is only called if the status has actually changed.
3. `isMobile` has been added to the `useEffect` dependency array to ensure the `onResize` closure always has the current `isMobile` value.

This optimization prevents unnecessary re-renders of the Layout and Sidebar components, resolving the scroll jumping issue and providing a smoother user experience on mobile. The fix also incorporates the earlier change from `h-screen` to `h-dvh` for the sidebar height, ensuring all buttons are reachable.