### PR TITLE
Fix: New task button not opening modal in TasksPage

### DIFF
--- a/src/frontend/src/pages/TasksPage.tsx
+++ b/src/frontend/src/pages/TasksPage.tsx
@@ -481,6 +481,7 @@ const TasksPage: React.FC = () => {
         )}
         {showAddTaskModal && (
           <AddTaskModal 
+    isOpen={showAddTaskModal}
             onClose={handleCloseAddTaskModal} 
             onSave={handleSaveNewTask} 
           />


### PR DESCRIPTION
The "Add New Task" button on the Tasks page was not working because the AddTaskModal component was not receiving the required `isOpen` prop.

This commit fixes the issue by passing the `showAddTaskModal` state variable from `TasksPage.tsx` as the `isOpen` prop to the `AddTaskModal` component. This ensures the modal renders correctly when you click the button.