### PR TITLE
Fix: Edit task button not opening modal in TasksPage

### DIFF
--- a/src/frontend/src/pages/TasksPage.tsx
+++ b/src/frontend/src/pages/TasksPage.tsx
@@ -474,6 +474,7 @@ const TasksPage: React.FC = () => {
 
         {showEditModal && editingTask && (
           <EditTaskModal 
+    isOpen={showEditModal}
             task={editingTask} 
             onClose={handleCloseEditModal} 
             onSave={handleSaveEdit} 


### PR DESCRIPTION
The "Edit" button for tasks on the Tasks page was not working because the EditTaskModal component was not receiving the required `isOpen` prop. This prevented the modal from rendering even when its controlling state variable `showEditModal` was true.

This commit fixes the issue by passing the `showEditModal` state variable from `TasksPage.tsx` as the `isOpen` prop to the `EditTaskModal` component. This ensures the modal renders correctly with the task's data when the edit button is clicked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the behavior of the task editing modal to ensure it opens and closes reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->