### PR TITLE
Fix LinkedIn regex for bookmark capture

### DIFF
--- a/src/backend/dist/api/controllers/captureController.js
+++ b/src/backend/dist/api/controllers/captureController.js
@@ -19,7 +19,7 @@ const processTelegramItemForBookmarks = async (telegramItem) => {
     }
     const socialMediaPatterns = {
         X: /https?:\/\/(twitter\.com|x\.com)/i,
-        LinkedIn: /https?:\/\/linkedin\.com/i,
+        LinkedIn: /https?:\/\/(?:www\.)?linkedin\.com/i,
     };
     for (const url of telegramItem.urls) {
         let platform = null;

--- a/src/backend/src/api/controllers/captureController.ts
+++ b/src/backend/src/api/controllers/captureController.ts
@@ -21,7 +21,7 @@ export const processTelegramItemForBookmarks = async (telegramItem: ITelegramIte
 
   const socialMediaPatterns = {
     X: /https?:\/\/(twitter\.com|x\.com)/i,
-    LinkedIn: /https?:\/\/linkedin\.com/i,
+    LinkedIn: /https?:\/\/(?:www\.)?linkedin\.com/i,
   };
 
   for (const url of telegramItem.urls) {


### PR DESCRIPTION
## Summary
- broaden LinkedIn URL detection so Telegram messages containing `www.linkedin.com` links are properly saved as bookmarks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6371696483319703116a1f440ae8