### PR TITLE
Fix: Prevent BookmarksPage from disappearing after load

### DIFF
--- a/src/frontend/src/pages/BookmarksPage.tsx
+++ b/src/frontend/src/pages/BookmarksPage.tsx
@@ -118,24 +118,6 @@ const BookmarksPage: React.FC = () => {
       setLoading(false);
     }
   }, [token, toast]);
-
-  // Add this useEffect to prevent framer-motion from unmounting the components
-  useEffect(() => {
-    // This effect is to ensure the component stays mounted
-    console.log("[BookmarksPage] Ensuring component stability");
-    
-    // Force stable rendering after initial load
-    if (!loading && bookmarks && bookmarks.length > 0) {
-      const timer = setTimeout(() => {
-        console.log("[BookmarksPage] Forcing stable render state");
-        // Force a re-render without changing state values
-        // by setting state to the same value
-        setBookmarks([...bookmarks]);
-      }, 300);
-      
-      return () => clearTimeout(timer);
-    }
-  }, [loading, bookmarks]);
   
   // Modify the fetchBookmarks useEffect
   useEffect(() => {
@@ -146,21 +128,31 @@ const BookmarksPage: React.FC = () => {
       console.error("[BookmarksPage] No authentication token available");
       setError("You must be logged in to view bookmarks. Please log in and try again.");
       setLoading(false);
+      setBookmarks(null); // Also clear bookmarks if token is lost
       return;
     }
     
-    // Fetch bookmarks only if we don't already have them
-    if (!bookmarks || currentPage !== lastPageFetched.current) {
-      lastPageFetched.current = currentPage;
+    // Fetch bookmarks if the page changed, or if bookmarks are not yet loaded for the current view.
+    // The `fetchBookmarksCallback` will handle the actual API call and state updates.
+    // `lastPageFetched.current` helps prevent re-fetching the same page if the effect runs
+    // due to other dependency changes (though `fetchBookmarksCallback` is stable).
+    if (currentPage !== lastPageFetched.current || !bookmarks) {
+      console.log(`[BookmarksPage] Conditions met to fetch. Current page: ${currentPage}, Last fetched: ${lastPageFetched.current}, Bookmarks exist: ${!!bookmarks}`);
+      lastPageFetched.current = currentPage; // Update last fetched page before calling fetch
       fetchBookmarksCallback(currentPage).catch(err => {
         console.error("[BookmarksPage] Unhandled error in fetchBookmarks effect:", err);
         setError(`Failed to load bookmarks: ${err.message || "Unknown error"}`);
-        setLoading(false);
+        setLoading(false); // Ensure loading is set to false on error
       });
     } else {
-      console.log("[BookmarksPage] Skipping fetch as we already have bookmarks for this page");
+      console.log(`[BookmarksPage] Skipping fetch for page ${currentPage}. lastPageFetched: ${lastPageFetched.current}, Bookmarks loaded: ${!!bookmarks}`);
+      // If we skipped fetch because data is already there, ensure loading is false.
+      // This can happen if token changes but page and data are current.
+      if (loading) {
+        setLoading(false);
+      }
     }
-  }, [fetchBookmarksCallback, currentPage, token, bookmarks]);
+  }, [fetchBookmarksCallback, currentPage, token]); // MODIFIED dependencies
 
   // Add a new useEffect specifically for authentication status changes
   useEffect(() => {
@@ -499,8 +491,8 @@ const BookmarksPage: React.FC = () => {
     return null;
   };
 
-  if (loading || bookmarks === null) {
-    console.log("[BookmarksPage] Rendering loading state because loading is true or bookmarks is null");
+  if (loading) {
+    console.log("[BookmarksPage] Rendering loading state because loading is true");
     return (
       <div className="p-4 md:p-8 min-h-screen bg-gradient-to-br from-background via-background to-muted/20 relative overflow-hidden">
         <div className="container mx-auto relative z-10">
@@ -539,6 +531,21 @@ const BookmarksPage: React.FC = () => {
     );
   }
 
+  // This case should ideally not be hit if API always returns an array for data (even empty)
+  // and if token loss sets an error. But as a fallback:
+  if (bookmarks === null) {
+    console.log("[BookmarksPage] Rendering fallback state: bookmarks is null, not loading, no error.");
+    return (
+      <div className="p-4 md:p-8 min-h-screen flex items-center justify-center bg-background">
+        {/* Minimal indicator, or could be a more specific message */}
+        <Loader2 className="w-12 h-12 animate-spin text-primary opacity-50" />
+        <p className="ml-4 text-muted-foreground">Preparing your bookmarks...</p>
+      </div>
+    );
+  }
+
+  // If we reach here, loading is false, error is null, and bookmarks is an array.
+  // The rest of the component rendering logic (calculating filteredAndSortedBookmarks, returning main layout) follows.
   // Calculate the bookmarks to display on every render for maximum safety
   const filteredAndSortedBookmarks = getFilteredAndSortedBookmarks();
 


### PR DESCRIPTION
The bookmarks page had an issue where content would appear briefly and then vanish. This was likely due to a combination of factors:

1. A `useEffect` hook intended for stability was forcing a re-render of the bookmarks list with `setBookmarks([...bookmarks])` on a 300ms timer after initial load. This could cause a flicker or reset the view. This hook has been removed.

2. The main data fetching `useEffect` hook had `bookmarks` in its dependency array, causing it to re-run unnecessarily when bookmarks were updated. This has been corrected by removing `bookmarks` from the dependencies, relying on `currentPage` and `token` changes to trigger fetches. Logic for handling token loss and ensuring `lastPageFetched` is correctly updated was also refined.

3. The conditional rendering logic for loading, error, and content states was flawed. Specifically, if an error occurred during initial load (when `bookmarks` was `null`), the loading skeleton would be shown instead of the error message. This has been fixed by prioritizing the `loading` state first, then the `error` state, and then handling the `bookmarks === null` case as a fallback.

These changes stabilize the component's state management and rendering lifecycle, ensuring a smoother user experience and correct display of UI states.