### PR TITLE
Add upcoming tasks and recent video to dashboard

### DIFF
--- a/src/frontend/src/components/Dashboard/RecentVideo.tsx
+++ b/src/frontend/src/components/Dashboard/RecentVideo.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { GlassCard } from '@/components/ui/GlassCard';
+import { AnimatedButton } from '@/components/ui/AnimatedButton';
+import { getVideosService } from '@/services/videoService';
+import { VideoItemType } from '@/types/video';
+import { Film } from 'lucide-react';
+
+const RecentVideo: React.FC = () => {
+  const [video, setVideo] = useState<VideoItemType | null>(null);
+
+  useEffect(() => {
+    const fetchVideos = async () => {
+      try {
+        const list = await getVideosService();
+        if (list.length > 0) {
+          const sorted = [...list].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+          setVideo(sorted[0]);
+        }
+      } catch (err) {
+        console.error('Failed to load videos:', err);
+      }
+    };
+    fetchVideos();
+  }, []);
+
+  if (!video) return null;
+
+  return (
+    <GlassCard className="mb-6">
+      <div className="p-6">
+        <div className="flex items-center mb-4">
+          <Film className="w-5 h-5 text-primary mr-2" />
+          <h3 className="text-lg font-semibold">Recent Video</h3>
+        </div>
+        <div className="flex items-center gap-4">
+          {video.thumbnailUrl && (
+            <img src={video.thumbnailUrl} alt={video.title} className="w-32 h-20 object-cover rounded" />
+          )}
+          <div className="flex-1">
+            <p className="font-medium mb-2 line-clamp-2 text-sm">{video.title}</p>
+            <AnimatedButton variant="secondary" size="sm" onClick={() => window.location.href = '/videos'}>
+              Watch
+            </AnimatedButton>
+          </div>
+        </div>
+      </div>
+    </GlassCard>
+  );
+};
+
+export default RecentVideo;

--- a/src/frontend/src/components/Dashboard/UpcomingEvents.tsx
+++ b/src/frontend/src/components/Dashboard/UpcomingEvents.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { Calendar } from 'lucide-react';
+import { GlassCard } from '@/components/ui/GlassCard';
+
+interface CalendarEvent {
+  id: number;
+  title: string;
+  startTime: string;
+  endTime: string;
+}
+
+const STORAGE_KEY = 'calendarEvents';
+
+const UpcomingEvents: React.FC = () => {
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+
+  const loadEvents = () => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as Array<Omit<CalendarEvent, 'startTime' | 'endTime'> & { startTime: string; endTime: string }>;
+        setEvents(parsed.map(e => ({ ...e, startTime: e.startTime, endTime: e.endTime })));
+      } else {
+        setEvents([]);
+      }
+    } catch (err) {
+      console.error('Failed to load calendar events:', err);
+      setEvents([]);
+    }
+  };
+
+  useEffect(() => {
+    loadEvents();
+    const handleUpdate = () => loadEvents();
+    window.addEventListener('calendarEventsUpdated', handleUpdate);
+    return () => {
+      window.removeEventListener('calendarEventsUpdated', handleUpdate);
+    };
+  }, []);
+
+  const upcoming = events
+    .map(e => ({ ...e, date: new Date(e.startTime) }))
+    .filter(e => e.date >= new Date())
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
+    .slice(0, 5);
+
+  if (upcoming.length === 0) {
+    return null;
+  }
+
+  return (
+    <GlassCard className="mb-6">
+      <div className="p-6">
+        <div className="flex items-center mb-4">
+          <Calendar className="w-5 h-5 text-primary mr-2" />
+          <h3 className="text-lg font-semibold">Upcoming Tasks</h3>
+        </div>
+        <ul className="space-y-2">
+          {upcoming.map(event => (
+            <li key={event.id} className="flex justify-between text-sm">
+              <span className="font-medium text-foreground truncate mr-2">{event.title}</span>
+              <span className="text-muted-foreground whitespace-nowrap">
+                {new Date(event.startTime).toLocaleDateString()} {new Date(event.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </GlassCard>
+  );
+};
+
+export default UpcomingEvents;

--- a/src/frontend/src/pages/DashboardPage.tsx
+++ b/src/frontend/src/pages/DashboardPage.tsx
@@ -12,6 +12,8 @@ import AddNoteModal from '@/components/notes/AddNoteModal';
 import useAuthStore from '@/store/authStore';
 import { BACKEND_ROOT_URL } from "@/services/axiosConfig";
 import { AnimatedDashboardCard, DashboardGrid } from '@/components/animations/AnimatedDashboardCard';
+import UpcomingEvents from '@/components/Dashboard/UpcomingEvents';
+import RecentVideo from '@/components/Dashboard/RecentVideo';
 
 const API_BASE_URL = `${BACKEND_ROOT_URL}/api/v1`;
 
@@ -334,6 +336,16 @@ const DashboardPage: React.FC = () => {
               </div>
             </GlassCard>
           ) : null}
+        </motion.div>
+
+        {/* Upcoming Tasks & Recent Video */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+        >
+          <UpcomingEvents />
+          <RecentVideo />
         </motion.div>
 
         {/* Welcome Section */}


### PR DESCRIPTION
## Summary
- show upcoming calendar tasks on the dashboard
- show the most recent video on the dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685923acfc048331a934aa7f77f93611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Recent Video" card to the dashboard, displaying the latest video with a thumbnail, title, and a "Watch" button.
  - Introduced an "Upcoming Tasks" card that lists up to five upcoming calendar events from your local storage.
- **Style**
  - Enhanced dashboard layout with animated transitions for new content sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->