### PR TITLE
Enable search across all bookmarks pages

### DIFF
--- a/src/backend/src/api/controllers/bookmarksController.ts
+++ b/src/backend/src/api/controllers/bookmarksController.ts
@@ -197,14 +197,30 @@ export const getBookmarks = async (req: AuthenticatedRequest, res: Response) => 
 
     const page = parseInt(req.query.page as string) || 1;
     const limit = parseInt(req.query.limit as string) || 10;
+    const search = (req.query.search as string) || '';
     const skip = (page - 1) * limit;
 
-    const bookmarks = await BookmarkItem.find({ userId: new Types.ObjectId(userId) })
+    const filter: any = { userId: new Types.ObjectId(userId) };
+    if (search) {
+      const regex = new RegExp(search, 'i');
+      filter.$or = [
+        { title: regex },
+        { summary: regex },
+        { originalUrl: regex },
+        { fetchedTitle: regex },
+        { fetchedDescription: regex },
+        { redditPostContent: regex },
+        { redditAuthor: regex },
+        { redditSubreddit: regex },
+      ];
+    }
+
+    const bookmarks = await BookmarkItem.find(filter)
       .sort({ createdAt: -1 })
       .skip(skip)
       .limit(limit);
 
-    const totalBookmarks = await BookmarkItem.countDocuments({ userId: new Types.ObjectId(userId) });
+    const totalBookmarks = await BookmarkItem.countDocuments(filter);
 
     res.status(200).json({
       data: bookmarks,

--- a/src/frontend/src/pages/BookmarksPage.tsx
+++ b/src/frontend/src/pages/BookmarksPage.tsx
@@ -76,7 +76,7 @@ const BookmarksPage: React.FC = () => {
     console.log(`[BookmarksPage] Fetching bookmarks for page: ${pageToFetch}...`);
     setLoading(true);
     try {
-      const response = await getBookmarks(pageToFetch, PAGE_LIMIT);
+      const response = await getBookmarks(pageToFetch, PAGE_LIMIT, searchTerm);
       console.log("[BookmarksPage] Fetched data:", JSON.stringify(response.data, null, 2));
       console.log("[BookmarksPage] API response structure:", {
         currentPage: response.currentPage,
@@ -118,7 +118,7 @@ const BookmarksPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [token, toast]);
+  }, [token, toast, searchTerm]);
   
   // Modify the fetchBookmarks useEffect
   useEffect(() => {
@@ -154,6 +154,13 @@ const BookmarksPage: React.FC = () => {
       }
     }
   }, [fetchBookmarksCallback, currentPage, token]); // MODIFIED dependencies
+
+  // Refetch when the search term changes
+  useEffect(() => {
+    if (!token) return;
+    setCurrentPage(1);
+    fetchBookmarksCallback(1);
+  }, [searchTerm, token, fetchBookmarksCallback]);
 
   // Add a new useEffect specifically for authentication status changes
   useEffect(() => {

--- a/src/frontend/src/services/bookmarkService.ts
+++ b/src/frontend/src/services/bookmarkService.ts
@@ -11,11 +11,15 @@ export interface PaginatedBookmarksResponse {
   totalBookmarks: number;
 }
 
-export const getBookmarks = async (page: number = 1, limit: number = 10): Promise<PaginatedBookmarksResponse> => {
+export const getBookmarks = async (
+  page: number = 1,
+  limit: number = 10,
+  search: string = ''
+): Promise<PaginatedBookmarksResponse> => {
   try {
     // Pass page and limit as query parameters
     const response = await axiosInstance.get<PaginatedBookmarksResponse>('/bookmarks', {
-      params: { page, limit }
+      params: { page, limit, search }
     });
     return response.data; // The entire paginated object is returned
   } catch (error) {


### PR DESCRIPTION
## Summary
- extend bookmarks API to support searching across all bookmarks
- allow passing a search term from the frontend service
- update bookmarks page to request search results from the backend
- refetch bookmarks when the search term changes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812c92b36c833187187cf03881e800