### PR TITLE
Execute typescript build and verify output

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -28,8 +28,8 @@ ENV NODE_OPTIONS="--max-old-space-size=512"
 # Copy package files from backend directory
 COPY src/backend/package*.json ./
 
-# Install dependencies with reduced memory usage
-RUN npm ci --legacy-peer-deps --production && \
+# Install ALL dependencies (including dev dependencies for build)
+RUN npm ci --legacy-peer-deps && \
     npm cache clean --force
 
 # Copy source code and config files from backend directory
@@ -52,8 +52,10 @@ RUN echo "Starting TypeScript build..." && \
     ls -la dist/server.js && \
     echo "Build verification complete"
 
-# Remove source files to reduce image size
-RUN rm -rf src/ tsconfig.json
+# Remove source files and dev dependencies to reduce image size
+RUN rm -rf src/ tsconfig.json && \
+    npm prune --production && \
+    npm cache clean --force
 
 # Expose common ports (Render will set PORT env var)
 EXPOSE 3001 10000


### PR DESCRIPTION
Install dev dependencies for Docker build and prune them to fix `tsc` command not found error.

The `npm ci --production` command in the Dockerfile prevented `tsc` from being installed, as it was a `devDependency`, leading to an exit code 127. This change ensures `tsc` is available for the build step while keeping the final image lean by pruning dev dependencies afterwards.

---
<a href="https://cursor.com/background-agent?bcId=bc-f210df54-90e6-408e-86d7-feef350e8d79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f210df54-90e6-408e-86d7-feef350e8d79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

