### PR TITLE
Investigate and fix waha service compliance issues

### DIFF
--- a/src/frontend/src/pages/WhatsAppPage.tsx
+++ b/src/frontend/src/pages/WhatsAppPage.tsx
@@ -519,9 +519,10 @@ const WhatsAppPage: React.FC = () => {
       
       // Prefer WAHA modern endpoint; fallback to legacy
       try {
-        const wahaRes = await api.get('/waha/private-chats');
+        // Request limited recent private chats to avoid timeouts and heavy payloads
+        const wahaRes = await api.get('/waha/private-chats?limit=200&sortBy=messageTimestamp&sortOrder=desc');
         if (wahaRes.data.success && Array.isArray(wahaRes.data.data)) {
-          console.log(`[WhatsApp Frontend] ✅ Fetched ${wahaRes.data.data.length} private chats via WAHA`);
+          console.log(`[WhatsApp Frontend] ✅ Fetched ${wahaRes.data.data.length} private chats via WAHA (limited)`);
           setPrivateChats(wahaRes.data.data);
           return;
         }


### PR DESCRIPTION
Implement pagination and optimized chat fetching to resolve WAHA service timeouts and improve chat loading reliability.

The "service exceeding" and chat loading issues were primarily caused by requesting all chats and messages at once, leading to oversized payloads and hitting upstream WAHA service limits or timeouts, especially during cold starts. This PR introduces server-side pagination and client-side limits to reduce payload size and adds robust retry logic for chat fetching.

---
<a href="https://cursor.com/background-agent?bcId=bc-876e8a54-c277-4794-8a56-ea4a1aa75bde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-876e8a54-c277-4794-8a56-ea4a1aa75bde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Private chats now support server-side pagination and sorting with sensible defaults.
  * Consistent client-side fallback preserves ordering and paging when server support is unavailable.
  * Responses include pagination metadata (limit, offset, total, hasMore) and return only the requested page.
  * Frontend fetches a limited, sorted batch of recent chats to improve load times and reduce bandwidth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->