### PR TITLE
Fix whatsapp monitor functionality

### DIFF
--- a/src/backend/src/services/groupMonitorService.ts
+++ b/src/backend/src/services/groupMonitorService.ts
@@ -245,6 +245,9 @@ class GroupMonitorService {
       // Process image for each monitor
       for (const monitor of monitors) {
         try {
+          // Count each incoming image message as a message processed for the monitor
+          await (monitor as any).incrementStats('messages');
+
           await this.processImageForMonitor(
             monitor,
             messageId,


### PR DESCRIPTION
Fix WhatsApp monitor showing 0 for messages/images by correcting the webhook URL and incrementing message counts for image messages.

The `WAHA` webhook was incorrectly posting to the `FRONTEND_URL`, preventing image messages from reaching the backend's group monitor endpoint. Additionally, the `groupMonitorService` was not incrementing the `totalMessages` statistic when processing image messages, leading to zero counts despite images being processed.

---
<a href="https://cursor.com/background-agent?bcId=bc-73bcc330-dee5-43a8-8c8f-a1b48c9ab0f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73bcc330-dee5-43a8-8c8f-a1b48c9ab0f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

