### PR TITLE
Fix whatsapp group chat id errors

### DIFF
--- a/WHATSAPP_INVALID_CHAT_ID_TROUBLESHOOTING.md
+++ b/WHATSAPP_INVALID_CHAT_ID_TROUBLESHOOTING.md
@@ -1,0 +1,213 @@
+## WAHA “Invalid chat id” Troubleshooting Guide (Groups and Private Chats)
+
+This guide documents how to diagnose and resolve “invalid chat id” errors when fetching WhatsApp messages via WAHA, focusing on group JIDs, URL encoding, and the difference between private chat and group identifiers. No code changes are required; this is a diagnostic and best-practices reference.
+
+### TL;DR
+- **Use the correct JID**:
+  - **Groups**: end with `@g.us` (example: `1234567890-1700000000@g.us`).
+  - **Private chats**: end with `@s.whatsapp.net` (example: `15551234567@s.whatsapp.net`).
+- **Always URL-encode the JID** when sending it in API paths or query strings: use `encodeURIComponent(jid)`.
+- **Never pass an object** as the chat id; extract a string JID (often at `_serialized`). Avoid sending `[object Object]`.
+- **Match by exact, normalized JID** everywhere (UI state, caches, server calls) to avoid cross-chat mixups.
+
+---
+
+### Common Symptoms
+- WAHA responds with `400` and message similar to “invalid chat id”.
+- UI shows messages for the wrong chat or no messages load for a valid group.
+- Network inspector shows requests where `chatId` looks like `[object Object]` or a JID missing `@g.us`.
+
+---
+
+### 1) Understand WhatsApp JIDs
+- **JID formats**:
+  - Group JIDs: `XXXXXXXXXXXXXXXX-YYYYYYYYYY@g.us`.
+  - Private JIDs: `phone_number@s.whatsapp.net`.
+- **Do not use** the group name, phone number alone, or a truncated id.
+- **Object-based IDs**: Libraries/SDKs often expose chat IDs as objects (e.g., `{ _serialized: "123@g.us", user: "123", server: "g.us" }`). You must extract the string JID.
+
+Good examples:
+```typescript
+// ✅ Group JID
+const groupJid = "1234567890-1700000000@g.us";
+
+// ✅ Private JID
+const privateJid = "15551234567@s.whatsapp.net";
+
+// ✅ From object-based id
+const idObj = { _serialized: "1234567890-1700000000@g.us", user: "1234567890-1700000000", server: "g.us" };
+const jid = idObj._serialized; // "1234567890-1700000000@g.us"
+```
+
+Bad examples:
+```typescript
+// ❌ Not a valid JID for WAHA requests
+const groupName = "My Team";
+const numberOnly = "15551234567";
+const objectId = { user: "123", server: "g.us" }; // Passing this object will break
+```
+
+---
+
+### 2) Always URL-Encode JIDs in API Calls
+`@`, `.`, and other characters in JIDs require proper encoding in URLs. Use `encodeURIComponent` for query params and path segments.
+
+Examples:
+```typescript
+// ✅ Query parameter
+api.get(`/waha/messages?chatId=${encodeURIComponent(jid)}&limit=50`);
+
+// ✅ Path parameter
+api.get(`/waha/chats/${encodeURIComponent(jid)}/messages?limit=50`);
+```
+
+CLI verification:
+```bash
+# ✅ Using data-urlencode for query param
+curl -G "https://your-backend/api/v1/waha/messages" \
+  --data-urlencode "chatId=1234567890-1700000000@g.us" \
+  --data-urlencode "limit=50"
+
+# ✅ Encoding in a path segment
+curl "https://your-backend/api/v1/waha/chats/1234567890-1700000000%40g.us/messages?limit=50"
+```
+
+Pitfalls:
+- ❌ Using `encodeURI` instead of `encodeURIComponent` on the JID (doesn’t encode `@`).
+- ❌ Forgetting to encode when the JID is in a path segment.
+
+---
+
+### 3) Distinguish Group vs Private Identifiers
+- **Groups**: Must use the full `@g.us` JID.
+- **Private**: Must use the full `@s.whatsapp.net` JID.
+- **Do not mix** formats. A group’s phone-number-only value or a private number without the `@s.whatsapp.net` suffix will fail.
+
+Validation helper (conceptual):
+```typescript
+const isGroupJid = (jid: string) => /@g\.us$/.test(jid);
+const isPrivateJid = (jid: string) => /@s\.whatsapp\.net$/.test(jid);
+```
+
+---
+
+### 4) Diagnose Object-Based IDs and “[object Object]”
+Add temporary logs to confirm what you are sending to the backend:
+```typescript
+console.log("Selected chat id: ", selectedChat?.id, typeof selectedChat?.id);
+```
+
+If you see an object, extract a string JID:
+```typescript
+function toJid(id: unknown): string | null {
+  if (!id) return null;
+  if (typeof id === "string") return id;
+  if (typeof id === "object") {
+    const obj = id as Record<string, unknown>;
+    if (typeof obj._serialized === "string") return obj._serialized;
+    if (typeof obj.id === "string") return obj.id;
+    if (typeof obj.user === "string" && typeof obj.server === "string") {
+      return `${obj.user}@${obj.server}`;
+    }
+  }
+  return null; // Don’t send a request if this returns null
+}
+```
+
+Symptoms of this issue:
+- Network requests show `chatId=[object Object]`.
+- Server logs show `Invalid chatId - received "[object Object]"`.
+
+---
+
+### 5) Exact JID Matching to Prevent Cross-Chat Mixups
+- Always key caches and UI state by the **exact JID string** you send to the server.
+- Avoid partial matching (e.g., `includes`)—use direct string equality.
+
+Examples of correct usage:
+```typescript
+// ✅ Cache by exact JID
+messagesCache[jid] = messages;
+
+// ✅ Compare with exact JID for the selected chat
+if (incoming.chatId === selectedChatJid) {
+  // update UI/state
+}
+```
+
+---
+
+### 6) Backend Sanity Checks (Diagnostics Only)
+If you control the backend adapter to WAHA, add temporary diagnostics to surface bad inputs (remove after confirming):
+```typescript
+// Pseudocode inside controller
+let chatId = req.params.chatId || req.query.chatId;
+if (chatId && typeof chatId !== "string") {
+  // try to extract a JID from known fields
+}
+if (!chatId || chatId === "[object Object]" || chatId.includes("[object")) {
+  return res.status(400).json({ error: "Invalid chatId" });
+}
+```
+
+This helps pinpoint whether the client is sending an object or a malformed JID.
+
+---
+
+### 7) Step-by-Step Diagnostic Checklist
+1. Select a failing chat and log `selectedChat.id` and its type.
+2. If it’s an object, extract `_serialized` or reconstruct `user@server`.
+3. Confirm the JID ends with the expected suffix:
+   - Group → `@g.us`
+   - Private → `@s.whatsapp.net`
+4. Ensure the request URL uses `encodeURIComponent(jid)`.
+5. Validate that the same exact JID is used for:
+   - Cache keys
+   - Selected chat comparison
+   - Server request parameter
+6. Re-run with the network tab open; verify `chatId` is a proper JID string.
+7. If still failing, list all chats from WAHA and copy a known-good JID:
+   - `GET /api/v1/waha/chats` (or your adapter’s equivalent)
+   - Find the target chat and use its `id/_serialized`.
+
+---
+
+### 8) Verification Commands
+```bash
+# Replace BACKEND_URL and JID accordingly
+BACKEND_URL="https://your-backend" \
+JID="1234567890-1700000000@g.us" \
+; curl -G "$BACKEND_URL/api/v1/waha/messages" \
+  --data-urlencode "chatId=$JID" \
+  --data-urlencode "limit=10" | jq '.success, (.data | length)'
+```
+
+Expected output:
+- `true` and a non-zero message count for a valid JID and chat with messages.
+
+---
+
+### 9) Known Pitfalls and Resolutions
+- **Missing domain suffix**: Add `@g.us` for groups or `@s.whatsapp.net` for private chats.
+- **Not encoding JID**: Encode with `encodeURIComponent` in both query and path usage.
+- **Object passed instead of string**: Extract `_serialized`/`id` or reconstruct from `{ user, server }`.
+- **Cross-chat message display**: Match and cache strictly by the precise JID.
+
+---
+
+### 10) Related Docs
+- Group monitoring overview: [WHATSAPP_GROUP_MONITOR.md](mdc:WHATSAPP_GROUP_MONITOR.md)
+- Message fixes summary: [WAHA_MESSAGE_FIXES_SUMMARY.md](mdc:WAHA_MESSAGE_FIXES_SUMMARY.md)
+- 405 troubleshooting: [WHATSAPP_405_ERROR_FIX.md](mdc:WHATSAPP_405_ERROR_FIX.md)
+- WAHA service wrapper (backend): [wahaService.ts](mdc:src/backend/src/services/wahaService.ts)
+- WhatsApp UI page (frontend): [WhatsAppPage.tsx](mdc:src/frontend/src/pages/WhatsAppPage.tsx)
+
+---
+
+### Outcome
+Following this guide stabilizes message fetching by:
+- Using the precise, normalized chat JID for every operation.
+- Preventing malformed requests via proper URL-encoding.
+- Avoiding object-to-string pitfalls that yield `[object Object]`.
+- Ensuring exact JID matching so messages show only for the selected chat.
+


### PR DESCRIPTION
Add a comprehensive troubleshooting guide for "invalid chat id" errors in WAHA to address recurring issues with WhatsApp chat ID handling.

This guide clarifies correct JID usage (@g.us, @s.whatsapp.net), the necessity of URL-encoding JIDs, and the distinction between private and group chat identifiers, documenting diagnostic steps and solutions. No code changes were made; this PR is purely documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c838815-1193-4397-810a-4a3f519ff821">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c838815-1193-4397-810a-4a3f519ff821">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

