### PR TITLE
Debug whatsapp group message fetching error

### DIFF
--- a/src/frontend/src/pages/WhatsAppPage.tsx
+++ b/src/frontend/src/pages/WhatsAppPage.tsx
@@ -127,16 +127,23 @@ const WhatsAppPage: React.FC = () => {
     }
     
     if (typeof chatId === 'string') {
-      return chatId;
+      const trimmed = chatId.trim();
+      if (!trimmed || trimmed === '[object Object]' || trimmed.includes('[object')) {
+        console.warn(`[WhatsApp Frontend] ⚠️ Invalid string chatId in ${context}:`, trimmed);
+        return null;
+      }
+      return trimmed;
     }
     
     if (typeof chatId === 'object' && chatId !== null) {
       // Extract string ID from object formats
       if ('_serialized' in chatId && typeof (chatId as any)._serialized === 'string') {
-        return (chatId as any)._serialized;
+        const v = (chatId as any)._serialized as string;
+        return v && v !== '[object Object]' && !v.includes('[object') ? v : null;
       }
       if ('id' in chatId && typeof (chatId as any).id === 'string') {
-        return (chatId as any).id;
+        const v = (chatId as any).id as string;
+        return v && v !== '[object Object]' && !v.includes('[object') ? v : null;
       }
       if ('user' in chatId && 'server' in chatId && typeof (chatId as any).user === 'string' && typeof (chatId as any).server === 'string') {
         return `${(chatId as any).user}@${(chatId as any).server}`;


### PR DESCRIPTION
Implement robust JID extraction and frontend validation to fix "invalid chat ID" errors for WhatsApp groups.

The "invalid chat ID" error occurred because group IDs were sometimes propagated as "[object Object]" from the WAHA backend to the frontend, leading to failed validation when attempting to fetch group message history. This PR ensures that chat IDs are correctly extracted and validated at both the backend and frontend, preventing malformed IDs from being used.

---
<a href="https://cursor.com/background-agent?bcId=bc-af1b390e-d19e-4ea5-8a51-b3d4c41fe1bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af1b390e-d19e-4ea5-8a51-b3d4c41fe1bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

