### PR TITLE
Fetch and save whatsapp chat images

### DIFF
--- a/src/backend/src/api/routes/wahaRoutes.ts
+++ b/src/backend/src/api/routes/wahaRoutes.ts
@@ -30,8 +30,11 @@ import {
   forceHistorySync,
   getMonitoredKeywords,
   addMonitoredKeyword,
-  removeMonitoredKeyword
+  removeMonitoredKeyword,
+  proxyMediaByUrl,
+  saveMediaToImages
 } from '../controllers/wahaController';
+import { authMiddleware } from '../middleware/authMiddleware';
 
 const router = Router();
 
@@ -54,6 +57,10 @@ router.post('/auth/verify', verifyPhoneAuthCode);
 // Messaging
 router.post('/send', sendMessage);
 router.post('/send-media', sendMedia);
+
+// Media utilities
+router.get('/media/proxy', proxyMediaByUrl);
+router.post('/media/save', authMiddleware, saveMediaToImages);
 
 // Chat management
 router.get('/chats', getChats);


### PR DESCRIPTION
Enable display of WhatsApp images in chat and allow users to save them to the Images page by clicking on them.

The original WhatsApp integration only displayed `[media]` for images. This PR introduces backend proxying for image display to circumvent CORS and authentication issues, and a backend saving mechanism to store images in GridFS, making them accessible via the existing Images page. The frontend is updated to use these new endpoints and provide a click-to-save user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-37c7b25c-fbf8-4661-b955-1f59dcc5ad57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37c7b25c-fbf8-4661-b955-1f59dcc5ad57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

