### PR TITLE
feat: make feedback widget draggable and dismissible

### DIFF
--- a/src/frontend/src/components/feedback/FeedbackWidget.tsx
+++ b/src/frontend/src/components/feedback/FeedbackWidget.tsx
@@ -27,6 +27,7 @@ export const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [quickType, setQuickType] = useState<'bug' | 'feature' | 'rating' | null>(null);
+  const [isVisible, setIsVisible] = useState(true);
 
   const positionClasses = {
     'bottom-right': 'bottom-6 right-6',
@@ -71,10 +72,24 @@ export const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({
     setIsOpen(false);
   };
 
+  if (!isVisible) return null;
+
   return (
     <>
       {/* Widget */}
-      <div className={`fixed z-40 ${positionClasses[position]} ${className}`}>
+      <motion.div
+        drag
+        dragMomentum={false}
+        style={{ touchAction: 'none' }}
+        className={`fixed z-40 ${positionClasses[position]} ${className} relative`}
+      >
+        <button
+          onClick={() => setIsVisible(false)}
+          className="absolute -top-2 -right-2 bg-muted text-muted-foreground hover:bg-muted/80 rounded-full p-1 shadow"
+          aria-label="Dismiss feedback widget"
+        >
+          <X className="w-3 h-3" />
+        </button>
         <AnimatePresence>
           {isOpen && showQuickActions && (
             <motion.div
@@ -186,12 +201,12 @@ export const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({
 
             {/* Pulse Animation */}
             <motion.div
-              className="absolute inset-0 rounded-full bg-primary"
-              animate={{ 
+              className="absolute inset-0 rounded-full bg-primary pointer-events-none"
+              animate={{
                 scale: [1, 1.2, 1],
                 opacity: [0.7, 0, 0.7]
               }}
-              transition={{ 
+              transition={{
                 duration: 3,
                 repeat: Infinity,
                 ease: "easeInOut"
@@ -204,9 +219,9 @@ export const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({
         {!isOpen && (
           <motion.div
             className={`
-              absolute ${position.includes('right') ? 'right-16' : 'left-16'} 
+              absolute ${position.includes('right') ? 'right-16' : 'left-16'}
               ${position.includes('bottom') ? 'bottom-2' : 'top-2'}
-              bg-card border border-border rounded-lg px-3 py-2 
+              bg-card border border-border rounded-lg px-3 py-2
               shadow-lg backdrop-blur-sm
               pointer-events-none opacity-0 group-hover:opacity-100
               transition-opacity duration-200
@@ -219,7 +234,7 @@ export const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({
             </span>
           </motion.div>
         )}
-      </div>
+      </motion.div>
 
       {/* Feedback Modal */}
       <FeedbackModal


### PR DESCRIPTION
## Summary
- allow floating drag movement for feedback widget
- add close button to hide feedback widget
- avoid pulse animation intercepting clicks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68bb397ff0c88331b5304a86f4744e33