### PR TITLE
feat: make feedback widget draggable and dismissible

### DIFF
--- a/src/frontend/src/components/feedback/FeedbackWidget.tsx
+++ b/src/frontend/src/components/feedback/FeedbackWidget.tsx
@@ -27,6 +27,8 @@ export const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [quickType, setQuickType] = useState<'bug' | 'feature' | 'rating' | null>(null);
+  const [isVisible, setIsVisible] = useState(true);
+  const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
 
   const positionClasses = {
     'bottom-right': 'bottom-6 right-6',
@@ -71,155 +73,179 @@ export const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({
     setIsOpen(false);
   };
 
+  if (!isVisible) return null;
+
   return (
     <>
       {/* Widget */}
-      <div className={`fixed z-40 ${positionClasses[position]} ${className}`}>
-        <AnimatePresence>
-          {isOpen && showQuickActions && (
-            <motion.div
-              className="mb-4 space-y-2"
-              initial={{ opacity: 0, y: 20, scale: 0.95 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: 20, scale: 0.95 }}
-              transition={{ duration: 0.2 }}
-            >
-              {quickActions.map((action, index) => (
+      <motion.div
+        drag
+        dragMomentum={false}
+        dragElastic={0}
+        style={{ x: dragPosition.x, y: dragPosition.y, touchAction: 'none' }}
+        onDragEnd={(_, info) => {
+          setDragPosition(prev => ({
+            x: prev.x + info.offset.x,
+            y: prev.y + info.offset.y
+          }));
+        }}
+        className={`fixed z-40 ${positionClasses[position]} ${className}`}
+      >
+        <div className="relative group">
+          <button
+            onClick={() => setIsVisible(false)}
+            className="absolute -top-2 -right-2 bg-muted text-muted-foreground hover:bg-muted/80 rounded-full p-1 shadow"
+            aria-label="Dismiss feedback widget"
+          >
+            <X className="w-3 h-3" />
+          </button>
+          <AnimatePresence>
+            {isOpen && showQuickActions && (
+              <motion.div
+                className="mb-4 space-y-2"
+                initial={{ opacity: 0, y: 20, scale: 0.95 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: 20, scale: 0.95 }}
+                transition={{ duration: 0.2 }}
+              >
+                {quickActions.map((action, index) => (
+                  <motion.div
+                    key={action.type}
+                    initial={{ opacity: 0, x: position.includes('right') ? 20 : -20 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ delay: index * 0.05 }}
+                  >
+                    <Button
+                      onClick={() => handleQuickAction(action.type)}
+                      className={`
+                        ${action.color} text-white
+                        min-w-[160px] justify-start gap-3
+                        shadow-lg hover:shadow-xl transition-all duration-200
+                        backdrop-blur-sm border border-white/20
+                      `}
+                    >
+                      {action.icon}
+                      <div className="text-left">
+                        <div className="font-medium text-sm">{action.label}</div>
+                        <div className="text-xs opacity-90">{action.description}</div>
+                      </div>
+                    </Button>
+                  </motion.div>
+                ))}
+
+                {/* General Feedback Button */}
                 <motion.div
-                  key={action.type}
                   initial={{ opacity: 0, x: position.includes('right') ? 20 : -20 }}
                   animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: index * 0.05 }}
+                  transition={{ delay: quickActions.length * 0.05 }}
                 >
                   <Button
-                    onClick={() => handleQuickAction(action.type)}
-                    className={`
-                      ${action.color} text-white 
-                      min-w-[160px] justify-start gap-3 
+                    onClick={handleOpenGeneral}
+                    variant="outline"
+                    className="
+                      min-w-[160px] justify-start gap-3
+                      bg-background/80 backdrop-blur-sm
+                      border-border hover:bg-muted
                       shadow-lg hover:shadow-xl transition-all duration-200
-                      backdrop-blur-sm border border-white/20
-                    `}
+                    "
                   >
-                    {action.icon}
+                    <MessageCircle className="w-4 h-4" />
                     <div className="text-left">
-                      <div className="font-medium text-sm">{action.label}</div>
-                      <div className="text-xs opacity-90">{action.description}</div>
+                      <div className="font-medium text-sm">General Feedback</div>
+                      <div className="text-xs text-muted-foreground">Share your thoughts</div>
                     </div>
                   </Button>
                 </motion.div>
-              ))}
-              
-              {/* General Feedback Button */}
-              <motion.div
-                initial={{ opacity: 0, x: position.includes('right') ? 20 : -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: quickActions.length * 0.05 }}
-              >
-                <Button
-                  onClick={handleOpenGeneral}
-                  variant="outline"
-                  className="
-                    min-w-[160px] justify-start gap-3 
-                    bg-background/80 backdrop-blur-sm 
-                    border-border hover:bg-muted
-                    shadow-lg hover:shadow-xl transition-all duration-200
-                  "
-                >
-                  <MessageCircle className="w-4 h-4" />
-                  <div className="text-left">
-                    <div className="font-medium text-sm">General Feedback</div>
-                    <div className="text-xs text-muted-foreground">Share your thoughts</div>
-                  </div>
-                </Button>
               </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* Main Toggle Button */}
+          <motion.div
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            <Button
+              onClick={() => {
+                if (showQuickActions) {
+                  setIsOpen(!isOpen);
+                } else {
+                  setShowModal(true);
+                }
+              }}
+              aria-label={isOpen ? 'Close feedback widget' : 'Open feedback widget'}
+              className={`
+                relative w-14 h-14 rounded-full
+                bg-primary hover:bg-primary/90 text-primary-foreground
+                shadow-lg hover:shadow-xl transition-all duration-300
+                ${isOpen ? 'rotate-45' : ''}
+              `}
+            >
+              <AnimatePresence mode="wait">
+                {isOpen ? (
+                  <motion.div
+                    key="close"
+                    initial={{ opacity: 0, rotate: -90 }}
+                    animate={{ opacity: 1, rotate: 0 }}
+                    exit={{ opacity: 0, rotate: 90 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    <X className="w-6 h-6" />
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="feedback"
+                    initial={{ opacity: 0, rotate: -90 }}
+                    animate={{ opacity: 1, rotate: 0 }}
+                    exit={{ opacity: 0, rotate: 90 }}
+                    transition={{ duration: 0.2 }}
+                    className="flex flex-col items-center gap-1"
+                  >
+                    <MessageCircle className="w-5 h-5" />
+                    {showQuickActions && (
+                      <ChevronUp className="w-3 h-3 opacity-60" />
+                    )}
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
+              {/* Pulse Animation */}
+              <motion.div
+                className="absolute inset-0 rounded-full bg-primary pointer-events-none"
+                animate={{
+                  scale: [1, 1.2, 1],
+                  opacity: [0.7, 0, 0.7]
+                }}
+                transition={{
+                  duration: 3,
+                  repeat: Infinity,
+                  ease: "easeInOut"
+                }}
+              />
+            </Button>
+          </motion.div>
+
+          {/* Tooltip */}
+          {!isOpen && (
+            <motion.div
+              className={`
+                absolute ${position.includes('right') ? 'right-16' : 'left-16'}
+                ${position.includes('bottom') ? 'bottom-2' : 'top-2'}
+                bg-card border border-border rounded-lg px-3 py-2
+                shadow-lg backdrop-blur-sm
+                pointer-events-none opacity-0 group-hover:opacity-100
+                transition-opacity duration-200
+              `}
+              initial={{ opacity: 0, scale: 0.95 }}
+              whileHover={{ opacity: 1, scale: 1 }}
+            >
+              <span className="text-sm font-medium text-foreground">
+                Give Feedback
+              </span>
             </motion.div>
           )}
-        </AnimatePresence>
-
-        {/* Main Toggle Button */}
-        <motion.div
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
-        >
-          <Button
-            onClick={() => {
-              if (showQuickActions) {
-                setIsOpen(!isOpen);
-              } else {
-                setShowModal(true);
-              }
-            }}
-            className={`
-              relative w-14 h-14 rounded-full
-              bg-primary hover:bg-primary/90 text-primary-foreground
-              shadow-lg hover:shadow-xl transition-all duration-300
-              ${isOpen ? 'rotate-45' : ''}
-            `}
-          >
-            <AnimatePresence mode="wait">
-              {isOpen ? (
-                <motion.div
-                  key="close"
-                  initial={{ opacity: 0, rotate: -90 }}
-                  animate={{ opacity: 1, rotate: 0 }}
-                  exit={{ opacity: 0, rotate: 90 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  <X className="w-6 h-6" />
-                </motion.div>
-              ) : (
-                <motion.div
-                  key="feedback"
-                  initial={{ opacity: 0, rotate: -90 }}
-                  animate={{ opacity: 1, rotate: 0 }}
-                  exit={{ opacity: 0, rotate: 90 }}
-                  transition={{ duration: 0.2 }}
-                  className="flex flex-col items-center gap-1"
-                >
-                  <MessageCircle className="w-5 h-5" />
-                  {showQuickActions && (
-                    <ChevronUp className="w-3 h-3 opacity-60" />
-                  )}
-                </motion.div>
-              )}
-            </AnimatePresence>
-
-            {/* Pulse Animation */}
-            <motion.div
-              className="absolute inset-0 rounded-full bg-primary"
-              animate={{ 
-                scale: [1, 1.2, 1],
-                opacity: [0.7, 0, 0.7]
-              }}
-              transition={{ 
-                duration: 3,
-                repeat: Infinity,
-                ease: "easeInOut"
-              }}
-            />
-          </Button>
-        </motion.div>
-
-        {/* Tooltip */}
-        {!isOpen && (
-          <motion.div
-            className={`
-              absolute ${position.includes('right') ? 'right-16' : 'left-16'} 
-              ${position.includes('bottom') ? 'bottom-2' : 'top-2'}
-              bg-card border border-border rounded-lg px-3 py-2 
-              shadow-lg backdrop-blur-sm
-              pointer-events-none opacity-0 group-hover:opacity-100
-              transition-opacity duration-200
-            `}
-            initial={{ opacity: 0, scale: 0.95 }}
-            whileHover={{ opacity: 1, scale: 1 }}
-          >
-            <span className="text-sm font-medium text-foreground">
-              Give Feedback
-            </span>
-          </motion.div>
-        )}
-      </div>
+        </div>
+      </motion.div>
 
       {/* Feedback Modal */}
       <FeedbackModal


### PR DESCRIPTION
## Summary
- allow floating drag movement for feedback widget
- add close button to hide feedback widget
- avoid pulse animation intercepting clicks
- track drag position so widget stays where users move it
- improve accessibility with aria label on toggle button
- keep widget fixed on screen by moving dismiss/tooltip logic to inner wrapper

## Testing
- `npm test` *(fails: A React Element from an older version of React was rendered)*
- `cd src/frontend && npm run type-check` *(fails: numerous TypeScript errors such as `Property 'error' does not exist on type 'PaginatedResponse<ScheduledAgent>'`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb397ff0c88331b5304a86f4744e33