### PR TITLE
fix: make summary buttons responsive

### DIFF
--- a/src/frontend/src/pages/WhatsAppGroupMonitorPage.tsx
+++ b/src/frontend/src/pages/WhatsAppGroupMonitorPage.tsx
@@ -758,7 +758,7 @@ Processing time: ${summary.processingStats.processingTimeMs}ms`;
         </motion.div>
 
         {/* Navigation Tabs */}
-        <div className="flex gap-4 mb-6">
+        <div className="flex flex-wrap gap-4 mb-6 w-full overflow-x-auto">
           <Button
             onClick={() => setSelectedView('persons')}
             variant={selectedView === 'persons' ? 'default' : 'outline'}
@@ -1127,7 +1127,7 @@ Processing time: ${summary.processingStats.processingTimeMs}ms`;
                         
                         {/* Summary Actions */}
                         <div className="space-y-3">
-                          <div className="flex gap-2">
+                          <div className="flex flex-col sm:flex-row gap-2">
                             <Button
                               onClick={() => generateTodaySummary(group.id)}
                               disabled={isLoading}


### PR DESCRIPTION
## Summary
- ensure WhatsApp group monitor navigation tabs wrap or scroll on small screens
- stack summary action buttons vertically on mobile for better visibility

## Testing
- `npm test` *(fails: WhatsAppSummarizationService emoji extraction, MeetingsPage recording tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc37253748833196c747130036d43d