### PR TITLE
fix: ensure create group monitor button works

### DIFF
--- a/src/frontend/src/pages/WhatsAppGroupMonitorPage.tsx
+++ b/src/frontend/src/pages/WhatsAppGroupMonitorPage.tsx
@@ -350,8 +350,15 @@ const WhatsAppGroupMonitorPage: React.FC = () => {
   };
 
   const createGroupMonitor = async () => {
+    // Derive group name from selected group if it's missing
+    const selectedGroup = whatsAppGroups.find(g => String(g.id) === String(monitorForm.groupId));
+    const payload = {
+      ...monitorForm,
+      groupName: monitorForm.groupName || selectedGroup?.name || '',
+    };
+
     // Enhanced validation with specific error messages
-    if (!monitorForm.groupId) {
+    if (!payload.groupId) {
       toast({
         title: "Validation Error",
         description: "Please select a WhatsApp group",
@@ -360,7 +367,7 @@ const WhatsAppGroupMonitorPage: React.FC = () => {
       return;
     }
 
-    if (!monitorForm.groupName) {
+    if (!payload.groupName) {
       toast({
         title: "Validation Error",
         description: "Group name is missing. Please reselect the group",
@@ -369,7 +376,7 @@ const WhatsAppGroupMonitorPage: React.FC = () => {
       return;
     }
 
-    if (monitorForm.targetPersons.length === 0) {
+    if (payload.targetPersons.length === 0) {
       toast({
         title: "Validation Error",
         description: "Please select at least one person to monitor",
@@ -379,10 +386,10 @@ const WhatsAppGroupMonitorPage: React.FC = () => {
     }
 
     try {
-      console.log('Creating group monitor with data:', monitorForm);
-      const response = await api.post('/group-monitor/monitors', monitorForm);
+      console.log('Creating group monitor with data:', payload);
+      const response = await api.post('/group-monitor/monitors', payload);
       if (response.data.success) {
-        setGroupMonitors([...groupMonitors, response.data.data]);
+        setGroupMonitors(prev => [...prev, response.data.data]);
         setMonitorForm({
           groupId: '',
           groupName: '',
@@ -403,10 +410,10 @@ const WhatsAppGroupMonitorPage: React.FC = () => {
       }
     } catch (error: any) {
       console.error('Error creating group monitor:', error);
-      console.error('Request data was:', monitorForm);
-      
+      console.error('Request data was:', payload);
+
       const errorMessage = error.response?.data?.error || error.message || "Failed to create group monitor";
-      
+
       toast({
         title: "Error",
         description: errorMessage,
@@ -1453,8 +1460,8 @@ Processing time: ${summary.processingStats.processingTimeMs}ms`;
                         value={monitorForm.groupId}
                         onChange={(e) => {
                           const selectedGroupId = e.target.value;
-                          const selectedGroup = whatsAppGroups.find(g => g.id === selectedGroupId);
-                          
+                          const selectedGroup = whatsAppGroups.find(g => String(g.id) === selectedGroupId);
+
                           if (selectedGroupId && selectedGroup) {
                             setMonitorForm(prev => ({
                               ...prev,
@@ -1473,7 +1480,7 @@ Processing time: ${summary.processingStats.processingTimeMs}ms`;
                       >
                         <option value="">Select a group</option>
                         {whatsAppGroups.map(group => (
-                          <option key={group.id} value={group.id}>
+                          <option key={group.id} value={String(group.id)}>
                             {group.name} ({group.participantCount} members)
                           </option>
                         ))}
@@ -1582,7 +1589,7 @@ Processing time: ${summary.processingStats.processingTimeMs}ms`;
                     <div className="flex gap-3 pt-4">
                       <Button
                         onClick={createGroupMonitor}
-                        disabled={!monitorForm.groupId || !monitorForm.groupName || monitorForm.targetPersons.length === 0}
+                        disabled={!monitorForm.groupId || monitorForm.targetPersons.length === 0}
                         className="flex-1 bg-green-500 hover:bg-green-600"
                       >
                         Create Monitor


### PR DESCRIPTION
## Summary
- derive selected group name before creating monitor and validate inputs
- support groups with numeric IDs and simplify button state when creating monitors

## Testing
- `npm test` *(fails: MeetingsPage tests, WhatsAppSummarizationService test)*

------
https://chatgpt.com/codex/tasks/task_e_68bc44c4c6508331a9a638ae57694705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically fills the group name from the selected WhatsApp group.
  - Shows participant counts in the WhatsApp group selector.

- Bug Fixes
  - Prevents creating a monitor without a selected group or target persons.
  - Ensures reliable group selection by handling IDs consistently.
  - Improves success and error notifications during monitor creation.

- Refactor
  - Streamlined creation flow with a unified payload and functional list updates.
  - Resets the form and closes the modal after successful creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->