### PR TITLE
fix: update group monitor message tracking

### DIFF
--- a/src/backend/src/api/controllers/groupMonitorController.ts
+++ b/src/backend/src/api/controllers/groupMonitorController.ts
@@ -575,7 +575,7 @@ class GroupMonitorController {
     try {
       const { messageId, groupId, senderId, senderName, imageUrl, caption } = req.body;
 
-      if (!messageId || !groupId || !senderId || !imageUrl) {
+      if (!messageId || !groupId || !senderId) {
         res.status(400).json({
           success: false,
           error: 'Missing required message data'
@@ -583,8 +583,8 @@ class GroupMonitorController {
         return;
       }
 
-      // Process the image in the background
-      this.groupMonitorService.processImageMessage(
+      // Process the message in the background
+      this.groupMonitorService.processGroupMessage(
         messageId,
         groupId,
         senderId,
@@ -592,7 +592,7 @@ class GroupMonitorController {
         imageUrl,
         caption
       ).catch(error => {
-        console.error('Background image processing failed:', error);
+        console.error('Background message processing failed:', error);
       });
 
       res.json({

--- a/src/backend/src/services/groupMonitorService.ts
+++ b/src/backend/src/services/groupMonitorService.ts
@@ -224,42 +224,49 @@ class GroupMonitorService {
   }
 
   /**
-   * Process WhatsApp image message for person detection
+   * Process WhatsApp group message (image optional)
    */
-  async processImageMessage(
+  async processGroupMessage(
     messageId: string,
     groupId: string,
     senderId: string,
     senderName: string,
-    imageUrl: string,
+    imageUrl?: string,
     caption?: string
   ): Promise<void> {
     try {
       // Get active monitors for this group
       const monitors = await this.getActiveMonitorsForGroup(groupId);
-      
+
       if (monitors.length === 0) {
         return; // No active monitors for this group
       }
 
-      // Process image for each monitor
+      // Process message for each monitor
       for (const monitor of monitors) {
         try {
-          await this.processImageForMonitor(
-            monitor,
-            messageId,
-            senderId,
-            senderName,
-            imageUrl,
-            caption
-          );
+          // Always increment message count
+          await (monitor as any).incrementStats('messages');
+
+          if (imageUrl) {
+            // Increment image count and process for matches
+            await (monitor as any).incrementStats('images');
+            await this.processImageForMonitor(
+              monitor,
+              messageId,
+              senderId,
+              senderName,
+              imageUrl,
+              caption
+            );
+          }
         } catch (error) {
-          console.error(`Error processing image for monitor ${monitor._id}:`, error);
+          console.error(`Error processing message for monitor ${monitor._id}:`, error);
           // Continue with other monitors
         }
       }
     } catch (error) {
-      console.error('Error processing image message:', error);
+      console.error('Error processing group message:', error);
     }
   }
 
@@ -282,9 +289,6 @@ class GroupMonitorService {
 
       // Call face recognition service
       const matchResult = await this.matchFacesInImage(imageUrl, targetPersonIds, monitor.settings.confidenceThreshold);
-
-      // Update monitor statistics
-      await (monitor as any).incrementStats('images');
 
       if (!matchResult.success) {
         console.error('Face matching failed:', matchResult.error);


### PR DESCRIPTION
## Summary
- track messages in group monitors and process images only when present
- allow WhatsApp group monitor webhook to accept messages without images
- forward all group messages from WAHA service to the group monitor webhook

## Testing
- `npm test` *(fails: expect(received).toContain(expected), React rendering warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4ebbb40883318aaabfe7925aab3a