### PR TITLE
Follow-up: Telegram Channels immediate add + RSS fallback (post-#141)

### DIFF
--- a/src/backend/src/api/controllers/telegramChannelController.ts
+++ b/src/backend/src/api/controllers/telegramChannelController.ts
@@ -106,6 +106,9 @@ export const addChannel = async (req: AuthenticatedRequest, res: Response) => {
     } else if (error.message.includes('Chat not found')) {
       statusCode = 404;
       message = 'Channel not found. Make sure the channel exists and is public.';
+    } else if (error.message.includes('No active bot found')) {
+      statusCode = 409;
+      message = 'No active Telegram bot configured for this user. Please configure your bot first.';
     }
 
     res.status(statusCode).json({ 

--- a/src/backend/src/services/telegramChannelService.ts
+++ b/src/backend/src/services/telegramChannelService.ts
@@ -23,27 +23,40 @@ class TelegramChannelService {
     try {
       console.log(`[TelegramChannelService] Adding channel: ${channelIdentifier} for user: ${userId}`);
 
-      // Validate channel exists and get info
-      const channelInfo = await this.getChannelInfo(channelIdentifier, userId);
+      // First, try to resolve channel info via Bot API
+      let channelInfo: any | null = null;
+      try {
+        channelInfo = await this.getChannelInfo(channelIdentifier, userId);
+      } catch (infoErr) {
+        console.warn(`[TelegramChannelService] getChannelInfo failed for ${channelIdentifier}:`, (infoErr as Error).message);
+        // Fallback: if it's a public channel by @username, allow adding without immediate bot access
+        if (!channelIdentifier.startsWith('@')) {
+          // For non-@ identifiers, we must have a resolvable chat
+          throw infoErr;
+        }
+      }
       
-      // Check if channel already exists for this user
+      // Determine a unique channelId key we will store
+      const resolvedChannelId = channelInfo?.id ? channelInfo.id.toString() : channelIdentifier; // use @username fallback
+
+      // Check if channel already exists for this user (by either numeric id or @username)
       const existingChannel = await TelegramChannel.findOne({
         userId: new mongoose.Types.ObjectId(userId),
-        channelId: channelInfo.id.toString()
+        channelId: resolvedChannelId
       });
 
       if (existingChannel) {
         throw new Error('Channel is already being monitored');
       }
 
-      // Create new channel record
+      // Create new channel record (fill what we know)
       const newChannel = new TelegramChannel({
         userId: new mongoose.Types.ObjectId(userId),
-        channelId: channelInfo.id.toString(),
-        channelTitle: channelInfo.title,
-        channelUsername: channelInfo.username,
-        channelDescription: channelInfo.description,
-        channelType: this.getChannelType(channelInfo.type),
+        channelId: resolvedChannelId,
+        channelTitle: channelInfo?.title || (channelIdentifier.startsWith('@') ? channelIdentifier.slice(1) : resolvedChannelId),
+        channelUsername: channelInfo?.username || (channelIdentifier.startsWith('@') ? channelIdentifier.slice(1) : undefined),
+        channelDescription: channelInfo?.description,
+        channelType: this.getChannelType(channelInfo?.type || (channelIdentifier.startsWith('@') ? 'channel' : 'group')),
         keywords: keywords || [],
         messages: [],
         isActive: true,
@@ -51,7 +64,7 @@ class TelegramChannelService {
       });
 
       await newChannel.save();
-      console.log(`[TelegramChannelService] ✅ Channel added: ${channelInfo.title}`);
+      console.log(`[TelegramChannelService] ✅ Channel added: ${newChannel.channelTitle}`);
 
       // Emit real-time update IMMEDIATELY so UI reflects the new channel without waiting
       if (io) {
@@ -387,12 +400,44 @@ class TelegramChannelService {
         const errorMessage = this.getPermissionErrorMessage(channelId, (accessError as Error).message);
         await this.markChannelWithError(channelId, userId, errorMessage);
         
-        throw new Error(errorMessage);
+        // Attempt RSS fallback for public channels even when bot cannot access
+        if (channelId.startsWith('@')) {
+          try {
+            const rssMessages = await this.tryRSSFeed(channelId);
+            if (rssMessages.length > 0) {
+              // Append RSS messages to channel
+              const channelDoc = await TelegramChannel.findOne({ channelId, userId: new mongoose.Types.ObjectId(userId) });
+              if (channelDoc) {
+                const newMessages = rssMessages.filter(msg => !channelDoc.messages.find(existing => existing.messageId === msg.messageId));
+                if (newMessages.length > 0) {
+                  channelDoc.messages.push(...newMessages);
+                  channelDoc.totalMessages += newMessages.length;
+                  channelDoc.lastFetchedAt = new Date();
+                  await channelDoc.save();
+
+                  // Emit real-time updates for new messages
+                  if (io) {
+                    io.emit('new_telegram_channel_messages', {
+                      userId: userId,
+                      channelId: channelDoc._id.toString(),
+                      messages: newMessages
+                    });
+                  }
+                }
+              }
+            }
+          } catch (rssErr) {
+            console.error(`[TelegramChannelService] RSS fallback failed after access error for ${channelId}:`, rssErr);
+          }
+        }
+        
+        // Return empty array so callers can continue gracefully without failing the add flow
+        return [];
       }
       
     } catch (error) {
       console.error(`[TelegramChannelService] Error in getRecentChannelMessages:`, error);
-      throw error;
+      return [];
     }
   }
 

--- a/src/frontend/src/pages/TelegramChannelsPage.tsx
+++ b/src/frontend/src/pages/TelegramChannelsPage.tsx
@@ -100,7 +100,14 @@ const TelegramChannelsPage: React.FC = () => {
   const handleAddChannel = async (channelData: { channelIdentifier: string; keywords: string[] }) => {
     // Prevent adding channels if bot is not configured
     if (!botStatus?.hasBot) {
+      // Close the add modal and open bot config to guide the user immediately
+      setIsAddModalOpen(false);
       setIsBotConfigOpen(true);
+      toast({
+        title: "Bot setup required",
+        description: "Please configure your Telegram bot before adding channels/groups.",
+        variant: "destructive"
+      });
       return;
     }
 


### PR DESCRIPTION
Follow-up to PR #141.

Enhancements to Telegram Channels flow so adding channels works immediately and reliably, even before the bot is added as admin to public channels.

What’s included
- Backend: addChannel now emits the new channel immediately and returns without blocking on initial message fetch; initial fetch runs in the background.
- Backend: clearer error mapping (e.g., No active bot found => 409).
- Backend: allow adding @public channels even when the bot cannot yet access them; stores @username and starts background fetch.
- Backend: if bot cannot access, attempt RSS fallback for public channels and append recent items, emitting real-time updates.
- Frontend (earlier in #141): Socket.IO connects to backend in production; Add Channel modal responsive; optimistic channel add in UI.

Why
Users reported that after clicking Add Channel on /telegram-channels nothing appeared. This was often due to waiting on initial bot fetch or lack of immediate bot access to public channels. The new behavior makes adds immediate and informs users via subsequent message population.

Testing
1) Add public @channelname → channel card should appear immediately.
2) If bot not yet added, messages may arrive via RSS fallback; real-time requires adding the bot.
3) Once bot is added to the channel/group, real-time updates flow.

Notes
- Safe incremental change; existing bot-first path still used when bot has access.
- Keeps Socket.IO connection targeting backend in production.