### PR TITLE
Fix whatsapp build failure

### DIFF
--- a/src/backend/src/api/controllers/wahaController.ts
+++ b/src/backend/src/api/controllers/wahaController.ts
@@ -404,7 +404,7 @@ export const getChats = async (req: Request, res: Response) => {
     
     console.log('[WAHA Controller] Getting chats with options:', options);
     const startTime = Date.now();
-    const chats = await wahaService.getChats(undefined, options);
+    const chats = await wahaService.getChats('default', options);
     const duration = Date.now() - startTime;
     
     console.log(`[WAHA Controller] ✅ Successfully fetched ${chats.length} chats in ${duration}ms`);
@@ -828,13 +828,13 @@ export const getGroups = async (req: Request, res: Response) => {
     const startTime = Date.now();
     
     // Try WAHA-compliant groups endpoint first
-    let groups = await wahaService.getGroups(undefined, options);
+    let groups = await wahaService.getGroups('default', options);
     if (!groups || groups.length === 0) {
       console.log('[WAHA Controller] No groups found, trying refresh...');
       // Ask WAHA to refresh then try again quickly
       const refreshResult = await wahaService.refreshGroups();
       console.log('[WAHA Controller] Group refresh result:', refreshResult);
-      groups = await wahaService.getGroups(undefined, options);
+      groups = await wahaService.getGroups('default', options);
     }
     
     const duration = Date.now() - startTime;
@@ -926,7 +926,7 @@ export const getPrivateChats = async (req: Request, res: Response) => {
 
     // DEBUG: Add detailed logging to trace getChats execution
     console.log('[WAHA Controller DEBUG] About to call wahaService.getChats()...');
-    const chats = await wahaService.getChats(undefined, { limit, offset, sortBy, sortOrder });
+    const chats = await wahaService.getChats('default', { limit, offset, sortBy, sortOrder });
     console.log('[WAHA Controller DEBUG] getChats returned:', {
       chatCount: chats?.length || 0,
       chats: chats?.slice(0, 3).map(c => ({ id: c.id, name: c.name, isGroup: c.isGroup })) || []

--- a/src/backend/src/api/controllers/whatsappSummaryController.ts
+++ b/src/backend/src/api/controllers/whatsappSummaryController.ts
@@ -47,7 +47,7 @@ export const getAvailableGroups = async (req: Request, res: Response) => {
       {
         $match: {
           'metadata.isGroup': true,
-          'metadata.groupName': { $exists: true, $ne: null, $ne: '' }
+          'metadata.groupName': { $exists: true, $nin: [null, ''] }
         }
       },
       {

--- a/src/backend/src/services/whatsappUnifiedService.ts
+++ b/src/backend/src/services/whatsappUnifiedService.ts
@@ -158,7 +158,7 @@ class WhatsAppUnifiedService extends EventEmitter {
     
     try {
       // Get chats from WAHA (no filtering - get everything)
-      const wahaChats = await this.wahaService.getChats(undefined, {
+      const wahaChats = await this.wahaService.getChats('default', {
         limit: options?.limit,
         offset: options?.offset,
         sortBy: 'id', // Fixed to only supported sortBy value
@@ -166,7 +166,7 @@ class WhatsAppUnifiedService extends EventEmitter {
       });
       
       // Get groups separately to ensure we have everything
-      const wahaGroups = await this.wahaService.getGroups(undefined, {
+      const wahaGroups = await this.wahaService.getGroups('default', {
         limit: options?.limit,
         offset: options?.offset,
         sortBy: options?.sortBy === 'name' ? 'subject' : (options?.sortBy as 'id' | 'subject'),


### PR DESCRIPTION
Add missing 'default' session parameter to WAHA `getChats` and `getGroups` calls and fix a duplicate MongoDB query key to resolve build failures.

The initial build failed because `wahaService.getChats` and `getGroups` were called without the required `sessionName` parameter, leading to a TypeScript error. After fixing this, a new TypeScript error emerged due to an invalid MongoDB query using duplicate `$ne` operators, which was resolved by using `$nin` instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd7149fc-eb60-447f-b7b7-0518dcbe9f59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd7149fc-eb60-447f-b7b7-0518dcbe9f59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

