### PR TITLE
fix(backend): repair whatsapp metadata schema duplication

### DIFF
--- a/src/backend/src/models/WhatsAppMessage.ts
+++ b/src/backend/src/models/WhatsAppMessage.ts
@@ -37,15 +37,11 @@ export interface IWhatsAppMessage extends Document {
   metadata?: {
     forwarded?: boolean;
     forwardedMany?: boolean;
-    isGroup?: boolean;
-    groupId?: string;
-    groupName?: string;
     referral?: {
       sourceUrl?: string;
       sourceId?: string;
       sourceType?: string;
     };
-    // Group/summary metadata used by summary queries
     isGroup?: boolean;
     groupId?: string;
     groupName?: string;
@@ -148,16 +144,12 @@ const WhatsAppMessageSchema: Schema<IWhatsAppMessage> = new Schema(
     metadata: {
       forwarded: { type: Boolean, default: false },
       forwardedMany: { type: Boolean, default: false },
-      isGroup: { type: Boolean, default: false, index: true },
-      groupId: { type: String, index: true },
-      groupName: { type: String, index: true },
       referral: {
         sourceUrl: String,
         sourceId: String,
         sourceType: String
       },
-      // Group/summary metadata used by summary queries
-      isGroup: { type: Boolean, index: true },
+      isGroup: { type: Boolean, default: false, index: true },
       groupId: { type: String, index: true },
       groupName: { type: String, index: true }
     }


### PR DESCRIPTION
## Summary
- remove the duplicate metadata fields added to `WhatsAppMessage` in commit 313f47d1 so TypeScript only sees one definition of each property
- keep the schema defaults and indexes while ensuring the interface and schema align for WAHA summaries

## Testing
- npm run build *(fails in container: missing backend TypeScript dependency because npm install is blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c8787743048331910db3df32626fdf