### PR TITLE
fix: enable scrolling in WhatsApp summary modal

### DIFF
--- a/src/frontend/src/components/ui/GlassCard.tsx
+++ b/src/frontend/src/components/ui/GlassCard.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { motion, HTMLMotionProps } from 'framer-motion';
 import { cn } from '@/lib/utils';
 
-interface GlassCardProps extends HTMLMotionProps<"div"> {
+interface GlassCardProps extends HTMLMotionProps<'div'> {
   children: React.ReactNode;
   className?: string;
   glowColor?: string;
   blur?: 'sm' | 'md' | 'lg' | 'xl';
   hover?: boolean;
+  contentClassName?: string;
 }
 
 export const GlassCard: React.FC<GlassCardProps> = ({
@@ -16,6 +17,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
   glowColor = 'rgba(99, 102, 241, 0.15)',
   blur = 'md',
   hover = true,
+  contentClassName,
   ...props
 }) => {
   const blurClasses = {
@@ -70,7 +72,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
       />
 
       {/* Content */}
-      <div className="relative z-10">
+      <div className={cn('relative z-10', contentClassName)}>
         {children}
       </div>
 

--- a/src/frontend/src/components/whatsapp/SummaryModal.tsx
+++ b/src/frontend/src/components/whatsapp/SummaryModal.tsx
@@ -164,7 +164,7 @@ const SummaryModal: React.FC<SummaryDisplayProps> = ({
           exit={{ scale: 0.95, opacity: 0 }}
           className="max-w-6xl w-full max-h-[90vh] overflow-hidden"
         >
-          <GlassCard className="flex flex-col h-full">
+          <GlassCard className="h-full" contentClassName="flex flex-col h-full min-h-0">
             {/* Header */}
             <div className="flex items-center justify-between p-6 border-b border-white/10">
               <div>
@@ -206,7 +206,7 @@ const SummaryModal: React.FC<SummaryDisplayProps> = ({
             </div>
 
             {/* Content */}
-            <div className="flex-1 overflow-y-auto p-6">
+            <div className="flex-1 overflow-y-auto p-6 min-h-0">
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 {/* Left Column - Overview & Stats */}
                 <div className="lg:col-span-2 space-y-6">

--- a/src/frontend/src/pages/WhatsAppGroupMonitorPage.tsx
+++ b/src/frontend/src/pages/WhatsAppGroupMonitorPage.tsx
@@ -1645,7 +1645,7 @@ Processing time: ${summary.processingStats.processingTimeMs}ms`;
                 exit={{ scale: 0.95, opacity: 0 }}
                 className="max-w-4xl w-full max-h-[90vh] overflow-hidden"
               >
-                <GlassCard className="h-full flex flex-col">
+                <GlassCard className="h-full" contentClassName="flex flex-col h-full min-h-0">
                   {/* Header */}
                   <div className="flex items-center justify-between p-6 border-b border-white/10">
                     <div>
@@ -1676,7 +1676,7 @@ Processing time: ${summary.processingStats.processingTimeMs}ms`;
                   </div>
 
                   {/* Content */}
-                  <div className="flex-1 overflow-y-auto p-6 space-y-6">
+                  <div className="flex-1 overflow-y-auto p-6 space-y-6 min-h-0">
                     {/* Overview */}
                     <div>
                       <h4 className="text-lg font-semibold text-white mb-3">Overview</h4>


### PR DESCRIPTION
## Summary
- add a contentClassName override to the GlassCard component so inner layouts can opt into flex behaviors
- update the WhatsApp summary modals to use the new hook and ensure their content areas allow vertical scrolling
- apply min-height safeguards so long summaries remain accessible on mobile viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd60fc9c70833183cd1148238c4a97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Downloaded WhatsApp group summaries now include an AI Insights section (Sentiment, Key Topics, Action Items, Important Events, Decisions Made) with clear bullet/checkmark formatting.
- Bug Fixes
  - Improved summary modal layout and scrolling behavior, ensuring stable height handling and preventing overflow issues.
- Refactor
  - Updated the card component to support styling of its inner content area, enabling the layout improvements without changing visible content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->