### PR TITLE
fix: keep glass cards scrollable on touch devices

### DIFF
--- a/src/frontend/src/components/ui/GlassCard.tsx
+++ b/src/frontend/src/components/ui/GlassCard.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { motion, HTMLMotionProps } from 'framer-motion';
 import { cn } from '@/lib/utils';
 
-interface GlassCardProps extends HTMLMotionProps<"div"> {
+interface GlassCardProps extends HTMLMotionProps<'div'> {
   children: React.ReactNode;
   className?: string;
   glowColor?: string;
   blur?: 'sm' | 'md' | 'lg' | 'xl';
   hover?: boolean;
+  contentClassName?: string;
 }
 
 export const GlassCard: React.FC<GlassCardProps> = ({
@@ -16,6 +17,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
   glowColor = 'rgba(99, 102, 241, 0.15)',
   blur = 'md',
   hover = true,
+  contentClassName,
   ...props
 }) => {
   const blurClasses = {
@@ -48,7 +50,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
   return (
     <motion.div
       className={cn(
-        "relative overflow-hidden rounded-2xl",
+        "group relative overflow-hidden rounded-2xl",
         "bg-white/20 dark:bg-white/10 sm:bg-white/10 sm:dark:bg-white/5",
         blurClasses[blur],
         "border border-white/20 dark:border-white/10",
@@ -63,14 +65,14 @@ export const GlassCard: React.FC<GlassCardProps> = ({
     >
       {/* Gradient glow effect */}
       <div
-        className="absolute inset-0 opacity-0 transition-opacity duration-300 hover:opacity-30 sm:hover:opacity-100"
+        className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-30 sm:group-hover:opacity-100"
         style={{
           background: `radial-gradient(circle at var(--mouse-x, 50%) var(--mouse-y, 50%), ${glowColor}, transparent 60%)`,
         }}
       />
 
       {/* Content */}
-      <div className="relative z-10">
+      <div className={cn('relative z-10', contentClassName)}>
         {children}
       </div>
 

--- a/src/frontend/src/components/whatsapp/SummaryModal.tsx
+++ b/src/frontend/src/components/whatsapp/SummaryModal.tsx
@@ -156,15 +156,15 @@ const SummaryModal: React.FC<SummaryDisplayProps> = ({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex justify-center items-stretch sm:items-center p-4"
       >
         <motion.div
           initial={{ scale: 0.95, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
           exit={{ scale: 0.95, opacity: 0 }}
-          className="max-w-6xl w-full max-h-[90vh] overflow-hidden"
+          className="w-full max-w-6xl overflow-hidden h-[calc(100vh-2rem)] supports-[height:100dvh]:h-[calc(100dvh-2rem)] sm:h-auto sm:max-h-[90vh]"
         >
-          <GlassCard className="flex flex-col h-full">
+          <GlassCard className="h-full" contentClassName="flex flex-col h-full min-h-0">
             {/* Header */}
             <div className="flex items-center justify-between p-6 border-b border-white/10">
               <div>
@@ -206,7 +206,7 @@ const SummaryModal: React.FC<SummaryDisplayProps> = ({
             </div>
 
             {/* Content */}
-            <div className="flex-1 overflow-y-auto p-6">
+            <div className="flex-1 overflow-y-auto p-6 min-h-0">
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 {/* Left Column - Overview & Stats */}
                 <div className="lg:col-span-2 space-y-6">

--- a/src/frontend/src/pages/WhatsAppGroupMonitorPage.tsx
+++ b/src/frontend/src/pages/WhatsAppGroupMonitorPage.tsx
@@ -1637,15 +1637,15 @@ Processing time: ${summary.processingStats.processingTimeMs}ms`;
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+              className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex justify-center items-stretch sm:items-center p-4"
             >
               <motion.div
                 initial={{ scale: 0.95, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 exit={{ scale: 0.95, opacity: 0 }}
-                className="max-w-4xl w-full max-h-[90vh] overflow-hidden"
+                className="w-full max-w-4xl overflow-hidden h-[calc(100vh-2rem)] supports-[height:100dvh]:h-[calc(100dvh-2rem)] sm:h-auto sm:max-h-[90vh]"
               >
-                <GlassCard className="h-full flex flex-col">
+                <GlassCard className="h-full" contentClassName="flex flex-col h-full min-h-0">
                   {/* Header */}
                   <div className="flex items-center justify-between p-6 border-b border-white/10">
                     <div>
@@ -1676,7 +1676,7 @@ Processing time: ${summary.processingStats.processingTimeMs}ms`;
                   </div>
 
                   {/* Content */}
-                  <div className="flex-1 overflow-y-auto p-6 space-y-6">
+                  <div className="flex-1 overflow-y-auto p-6 space-y-6 min-h-0">
                     {/* Overview */}
                     <div>
                       <h4 className="text-lg font-semibold text-white mb-3">Overview</h4>


### PR DESCRIPTION
## Summary
- mark the GlassCard wrapper as a group so hover styling can use group-hover utilities
- disable pointer interactions on the glow overlay so scroll gestures reach the card content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd60fc9c70833183cd1148238c4a97