### PR TITLE
Fix whatsapp backend build failure

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -81,8 +81,8 @@
         "whatsapp-web.js": "^1.23.0"
       },
       "devDependencies": {
-        "@types/express": "^5.0.3",
-        "@types/express-serve-static-core": "^5.0.7",
+        "@types/express": "^4.17.21",
+        "@types/express-serve-static-core": "^4.19.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/marked": "^4.0.0",
         "@types/node": "^24.3.0",
@@ -3194,20 +3194,21 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
-      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
-      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -86,8 +86,8 @@
     "whatsapp-web.js": "^1.23.0"
   },
   "devDependencies": {
-    "@types/express": "^5.0.3",
-    "@types/express-serve-static-core": "^5.0.7",
+    "@types/express": "^4.17.21",
+    "@types/express-serve-static-core": "^4.19.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/marked": "^4.0.0",
     "@types/node": "^24.3.0",

--- a/src/backend/src/api/controllers/agentsController.ts
+++ b/src/backend/src/api/controllers/agentsController.ts
@@ -198,13 +198,13 @@ export const updateAgent = async (req: AuthenticatedRequest, res: Response): Pro
       return;
     }
     
-    const updates = req.body;
+    const updates: Record<string, any> = req.body || {};
     
     // Don't allow updating certain fields
-    delete updates._id;
-    delete updates.userId;
-    delete updates.createdAt;
-    delete updates.updatedAt;
+    delete (updates as any)._id;
+    delete (updates as any).userId;
+    delete (updates as any).createdAt;
+    delete (updates as any).updatedAt;
     
     const updatedAgent = await agentService.updateAgent(agentId, updates);
     

--- a/src/backend/src/api/controllers/calendarEventsController.ts
+++ b/src/backend/src/api/controllers/calendarEventsController.ts
@@ -1,10 +1,11 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
+import { AuthenticatedRequest } from '../../types/express';
 import CalendarEvent, { ICalendarEvent } from '../../models/CalendarEvent';
 import GoogleCalendarService from '../../services/googleCalendarService';
 import mongoose from 'mongoose';
 
 // Get all calendar events for the authenticated user
-export const getAllCalendarEvents = async (req: Request, res: Response) => {
+export const getAllCalendarEvents = async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id; // Assuming req.user is populated by auth middleware
     if (!userId) {
@@ -23,7 +24,7 @@ export const getAllCalendarEvents = async (req: Request, res: Response) => {
 };
 
 // Create a new calendar event
-export const createCalendarEvent = async (req: Request, res: Response) => {
+export const createCalendarEvent = async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id;
     if (!userId) {
@@ -70,7 +71,7 @@ export const createCalendarEvent = async (req: Request, res: Response) => {
 };
 
 // Update an existing calendar event
-export const updateCalendarEvent = async (req: Request, res: Response) => {
+export const updateCalendarEvent = async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id;
     const eventId = req.params.id;
@@ -179,7 +180,7 @@ export const updateCalendarEvent = async (req: Request, res: Response) => {
 };
 
 // Delete a calendar event
-export const deleteCalendarEvent = async (req: Request, res: Response) => {
+export const deleteCalendarEvent = async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id;
     const eventId = req.params.id;
@@ -287,7 +288,7 @@ const initializeGoogleCalendarService = () => {
 };
 
 // Sync calendar with Google Calendar
-export const syncWithGoogleCalendar = async (req: Request, res: Response) => {
+export const syncWithGoogleCalendar = async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id;
     const { accessToken, timeRange } = req.body;
@@ -383,7 +384,7 @@ export const syncWithGoogleCalendar = async (req: Request, res: Response) => {
 };
 
 // Get sync status
-export const getSyncStatus = async (req: Request, res: Response) => {
+export const getSyncStatus = async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id;
 
@@ -407,7 +408,7 @@ export const getSyncStatus = async (req: Request, res: Response) => {
 };
 
 // Import events from Google Calendar
-export const importFromGoogleCalendar = async (req: Request, res: Response) => {
+export const importFromGoogleCalendar = async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id;
     const { accessToken, timeMin, timeMax } = req.body;
@@ -444,7 +445,7 @@ export const importFromGoogleCalendar = async (req: Request, res: Response) => {
 };
 
 // Export events to Google Calendar
-export const exportToGoogleCalendar = async (req: Request, res: Response) => {
+export const exportToGoogleCalendar = async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id;
     const { accessToken } = req.body;
@@ -479,7 +480,7 @@ export const exportToGoogleCalendar = async (req: Request, res: Response) => {
 };
 
 // Debug endpoint to check database state
-export const debugCalendarEvents = async (req: Request, res: Response) => {
+export const debugCalendarEvents = async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id;
     if (!userId) {

--- a/src/backend/src/api/controllers/ideasController.ts
+++ b/src/backend/src/api/controllers/ideasController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import Idea, { IIdea } from '../../models/Idea';
 import mongoose from 'mongoose';
 import { AuthenticatedRequest } from '../../types/express';

--- a/src/backend/src/api/controllers/newsController.ts
+++ b/src/backend/src/api/controllers/newsController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import mongoose from 'mongoose';
 import { AuthenticatedRequest } from '../../types/express';
 import NewsItem, { INewsItem } from '../../models/NewsItem';

--- a/src/backend/src/api/controllers/scheduledAgentController.ts
+++ b/src/backend/src/api/controllers/scheduledAgentController.ts
@@ -214,7 +214,7 @@ export const updateScheduledAgent = async (req: AuthenticatedRequest, res: Respo
   try {
     const { id } = req.params;
     const userId = req.user?.id;
-    const updates = req.body;
+    const updates: Record<string, any> = req.body || {};
 
     console.log(`[ScheduledAgent] UPDATE request for agent ID: ${id}, User ID: ${userId}`);
 
@@ -238,11 +238,11 @@ export const updateScheduledAgent = async (req: AuthenticatedRequest, res: Respo
     }
 
     // Remove sensitive fields that shouldn't be updated directly
-    delete updates.userId;
-    delete updates.executionCount;
-    delete updates.successCount;
-    delete updates.failureCount;
-    delete updates.lastResult;
+    delete (updates as any).userId;
+    delete (updates as any).executionCount;
+    delete (updates as any).successCount;
+    delete (updates as any).failureCount;
+    delete (updates as any).lastResult;
 
     console.log(`[ScheduledAgent] Attempting to update agent with ID: ${id} and userId: ${userId}`);
 

--- a/src/backend/src/api/controllers/videosController.ts
+++ b/src/backend/src/api/controllers/videosController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import VideoItem, { IVideoItem } from '../../models/VideoItem';
 import KeywordSubscription from '../../models/KeywordSubscription';
 import {

--- a/src/backend/src/types/express.ts
+++ b/src/backend/src/types/express.ts
@@ -1,11 +1,11 @@
-﻿import { Request as ExpressRequest, Response, NextFunction } from 'express';
+import { Request as ExpressRequest, Response, NextFunction } from 'express';
 import { ParamsDictionary } from 'express-serve-static-core';
 import { ParsedQs } from 'qs';
 
 export interface AuthenticatedRequest<
   P = ParamsDictionary,
-  ResBody = unknown,
-  ReqBody = unknown,
+  ResBody = any,
+  ReqBody = any,
   ReqQuery = ParsedQs,
 > extends ExpressRequest<P, ResBody, ReqBody, ReqQuery> {
   user: {


### PR DESCRIPTION
Fix backend build failure by resolving TypeScript type conflicts between `express@4` and `@types/express@5`.

The build failed because `@types/express` and `@types/express-serve-static-core` were incorrectly pinned to v5, while the project uses `express@^4.21.2`. This mismatch caused 157 TypeScript errors, primarily affecting `req.body` and `req.user` typings in controllers. This PR downgrades the type packages and standardizes controller request typings.

---
<a href="https://cursor.com/background-agent?bcId=bc-5834f49a-dfce-4173-9bd1-620a72520961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5834f49a-dfce-4173-9bd1-620a72520961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

