### PR TITLE
Fix mobile task deletion gray page bug

### DIFF
--- a/src/frontend/src/pages/TasksPage.tsx
+++ b/src/frontend/src/pages/TasksPage.tsx
@@ -65,6 +65,7 @@ const TasksPage: React.FC = () => {
   const [taskForCalendar, setTaskForCalendar] = useState<Task | null>(null);
   const [sendingReminder, setSendingReminder] = useState<boolean>(false);
   const [viewMode, setViewMode] = useState<'list' | 'kanban'>('list');
+  const [confirmDeleteTask, setConfirmDeleteTask] = useState<{ id: string; title: string } | null>(null);
 
   const containerVariants = {
     hidden: { opacity: 0 },
@@ -573,35 +574,14 @@ const TasksPage: React.FC = () => {
                     >
                       <Edit size={14} className="mr-1" /> Edit
                     </AnimatedButton>
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <AnimatedButton 
-                          size="sm" 
-                          variant="outline"
-                          className="border-red-500/50 text-red-300 hover:bg-red-500/20 hover:border-red-500 glow-red-sm"
-                        >
-                          <Trash2 size={14} className="mr-1"/> Delete
-                        </AnimatedButton>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent className="glass bg-background/80 border-border/30">
-                        <AlertDialogHeader>
-                          <AlertDialogTitle className="text-foreground">Are you absolutely sure?</AlertDialogTitle>
-                          <AlertDialogDescription className="text-muted-foreground">
-                            This action cannot be undone. This will permanently delete the task
-                            "<strong>{task.title}</strong>".
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel className="hover:bg-muted/20">Cancel</AlertDialogCancel>
-                          <AlertDialogAction 
-                            onClick={() => handleDelete(task._id)} 
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                          >
-                            Delete
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
+                    <AnimatedButton 
+                      size="sm" 
+                      variant="outline"
+                      onClick={() => setConfirmDeleteTask({ id: task._id, title: task.title })}
+                      className="border-red-500/50 text-red-300 hover:bg-red-500/20 hover:border-red-500 glow-red-sm"
+                    >
+                      <Trash2 size={14} className="mr-1"/> Delete
+                    </AnimatedButton>
                   </div>
                 </GlassCard>
               </motion.div>
@@ -632,6 +612,27 @@ const TasksPage: React.FC = () => {
             onEventAdded={handleEventAddedToCalendar}
           />
         )}
+        {/* Centralized Delete Confirmation Dialog to avoid orphaned overlays on mobile */}
+        <AlertDialog open={!!confirmDeleteTask} onOpenChange={(open: boolean) => { if (!open) setConfirmDeleteTask(null); }}>
+          <AlertDialogContent className="glass bg-background/80 border-border/30">
+            <AlertDialogHeader>
+              <AlertDialogTitle className="text-foreground">Are you absolutely sure?</AlertDialogTitle>
+              <AlertDialogDescription className="text-muted-foreground">
+                This action cannot be undone. This will permanently delete the task
+                {confirmDeleteTask ? ` "${confirmDeleteTask.title}".` : '.'}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel className="hover:bg-muted/20">Cancel</AlertDialogCancel>
+              <AlertDialogAction 
+                onClick={() => { if (confirmDeleteTask) { setConfirmDeleteTask(null); handleDelete(confirmDeleteTask.id); } }} 
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </motion.div>
     </div>
   );


### PR DESCRIPTION
Centralize task deletion confirmation dialog to fix orphaned gray overlay on mobile.

The previous implementation created a separate `AlertDialog` for each task card. On mobile, this could lead to an `AlertDialog` remaining open and blocking interaction after a task was deleted or navigation occurred. This change uses a single, controlled `AlertDialog` instance for all task deletions, ensuring it always closes correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-99edab06-0925-4337-ac9f-5a3483342cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99edab06-0925-4337-ac9f-5a3483342cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces per-task delete dialogs with a single controlled AlertDialog to prevent orphaned overlays on mobile.
> 
> - **TasksPage (`src/frontend/src/pages/TasksPage.tsx`)**:
>   - Consolidates per-card `AlertDialog` into one centralized, controlled dialog.
>     - Adds `confirmDeleteTask` state to track the task being deleted.
>     - Updates Delete button to set `confirmDeleteTask` instead of opening a per-item dialog.
>     - Renders a single `AlertDialog` bound to this state; on confirm, calls `handleDelete` with the selected task id.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b432db163d6e12efce1bccaf972251405b4f0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->