### PR TITLE
Fix dashboard card text overflow on mobile

### DIFF
--- a/src/frontend/src/components/animations/AnimatedDashboardCard.tsx
+++ b/src/frontend/src/components/animations/AnimatedDashboardCard.tsx
@@ -43,11 +43,11 @@ export const AnimatedDashboardCard: React.FC<AnimatedDashboardCardProps> = ({
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay, duration: 0.5, ease: 'easeOut' }}
       whileHover={{ y: -4 }}
-      className="group"
+      className="group min-w-0"
     >
       <GlassCard 
         className={cn(
-          "relative overflow-hidden transition-all duration-300",
+          "relative w-full min-w-0 overflow-hidden transition-all duration-300",
           "hover:shadow-lg hover-glow cursor-pointer",
           onClick && "cursor-pointer"
         )}
@@ -71,10 +71,10 @@ export const AnimatedDashboardCard: React.FC<AnimatedDashboardCardProps> = ({
           }}
         />
 
-        <div className="relative p-6">
+        <div className="relative p-6 min-w-0">
           {/* Header */}
-          <div className="flex items-start justify-between mb-4">
-            <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
+          <div className="flex items-start justify-between mb-4 min-w-0">
+            <h3 className="text-sm font-medium text-muted-foreground truncate max-w-full">{title}</h3>
             {Icon && (
               <motion.div
                 whileHover={{ scale: 1.1, rotate: 5 }}
@@ -96,7 +96,7 @@ export const AnimatedDashboardCard: React.FC<AnimatedDashboardCardProps> = ({
               damping: 20
             }}
           >
-            <p className="text-3xl font-bold gradient-text">
+            <p className="text-3xl font-bold gradient-text break-words">
               {value}
             </p>
           </motion.div>
@@ -145,19 +145,22 @@ export const AnimatedDashboardCard: React.FC<AnimatedDashboardCardProps> = ({
 interface DashboardGridProps {
   children: React.ReactNode;
   columns?: number;
+  className?: string;
 }
 
 export const DashboardGrid: React.FC<DashboardGridProps> = ({ 
   children, 
-  columns = 4 
+  columns = 4,
+  className
 }) => {
   return (
     <motion.div
       className={cn(
-        "grid gap-6",
+        "grid w-full min-w-0",
         columns === 4 && "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
         columns === 3 && "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
-        columns === 2 && "grid-cols-1 md:grid-cols-2"
+        columns === 2 && "grid-cols-1 md:grid-cols-2",
+        className
       )}
       initial="hidden"
       animate="visible"

--- a/src/frontend/src/components/ui/GlassCard.tsx
+++ b/src/frontend/src/components/ui/GlassCard.tsx
@@ -50,7 +50,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
   return (
     <motion.div
       className={cn(
-        "relative overflow-hidden rounded-2xl group",
+        "relative w-full min-w-0 overflow-hidden rounded-2xl group",
         "bg-white/20 dark:bg-white/10 sm:bg-white/10 sm:dark:bg-white/5",
         blurClasses[blur],
         "border border-white/20 dark:border-white/10",

--- a/src/frontend/src/pages/DashboardPage.tsx
+++ b/src/frontend/src/pages/DashboardPage.tsx
@@ -457,7 +457,7 @@ const DashboardPage: React.FC = () => {
           </nav>
         </div>
 
-        <DashboardGrid columns={4} className="gap-3 sm:gap-4 lg:gap-6 overflow-hidden">
+        <DashboardGrid columns={4} className="gap-3 sm:gap-4 lg:gap-6 min-w-0">
           {stats.map((stat, index) => (
             <AnimatedDashboardCard
               key={stat.title}


### PR DESCRIPTION
Fix dashboard card text overflow on mobile by applying responsive width constraints and text handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-652d6405-b8e9-407a-8a05-eee998f4036c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-652d6405-b8e9-407a-8a05-eee998f4036c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

