### PR TITLE
Fix whatsapp image feature build failure

### DIFF
--- a/src/backend/src/services/wahaService.ts
+++ b/src/backend/src/services/wahaService.ts
@@ -34,6 +34,7 @@ export interface WAHAMessage {
   mimeType?: string;
   hasMedia?: boolean;
   mediaUrl?: string; // Added for compatibility
+  caption?: string; // Caption for media messages
   media?: {
     url?: string;
     mimetype?: string;


### PR DESCRIPTION
Add `caption` property to `WAHAMessage` interface to fix a TypeScript compilation error.

The previous PR #172 introduced code that accessed `fullMessage.caption` for media messages, but the `WAHAMessage` interface did not define this property, leading to a build failure. This change resolves the missing type definition.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0e829b2-5264-4599-a595-aacf6fd7c786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0e829b2-5264-4599-a595-aacf6fd7c786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

