### PR TITLE
Add onboarding button for user interests

### DIFF
--- a/src/frontend/src/pages/NewsHubPage.tsx
+++ b/src/frontend/src/pages/NewsHubPage.tsx
@@ -568,14 +568,24 @@ const NewsHubPage: React.FC = () => {
               </p>
             </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              onClick={() => setShowOnboarding(true)}
+              variant="outline"
+              className="flex items-center gap-2"
+            >
+              <Sparkles className="w-4 h-4" />
+              <span className="hidden sm:inline">Setup Interests</span>
+              <span className="sm:hidden">Setup</span>
+            </Button>
             <Button
               onClick={() => setInterestsModalOpen(true)}
               variant="outline"
               className="flex items-center gap-2"
             >
               <Settings className="w-4 h-4" />
-              Manage Interests
+              <span className="hidden sm:inline">Manage Interests</span>
+              <span className="sm:hidden">Manage</span>
             </Button>
             <Button
               onClick={handleRefresh}


### PR DESCRIPTION
Add a "Setup Interests" button to the News Hub header to allow users to manually re-trigger the onboarding flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f57d55b-ad82-4819-9324-1ef9e17d6dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f57d55b-ad82-4819-9324-1ef9e17d6dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

