### PR TITLE
Fix image issue

### DIFF
--- a/src/frontend/src/pages/NewsHubPage.tsx
+++ b/src/frontend/src/pages/NewsHubPage.tsx
@@ -90,11 +90,16 @@ const NewsHubPage: React.FC = () => {
       setArticles(response.data);
       setTotalPages(response.pagination.totalPages);
     } catch (error: any) {
-      toast({
-        title: 'Error',
-        description: 'Failed to fetch news feed',
-        variant: 'destructive'
-      });
+      console.error('Failed to fetch news feed:', error);
+      
+      // Don't show error toast if it's just a 404 (no articles yet)
+      if (error?.response?.status !== 404) {
+        toast({
+          title: 'Error',
+          description: 'Failed to fetch news feed. Please try again.',
+          variant: 'destructive'
+        });
+      }
     } finally {
       setLoading(false);
     }
@@ -139,8 +144,21 @@ const NewsHubPage: React.FC = () => {
           setShowOnboarding(true);
         }
       }
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to fetch user interests:', error);
+      
+      // If 404, it means user interests don't exist yet - show onboarding
+      if (error?.response?.status === 404 || error?.message?.includes('404')) {
+        setShowOnboarding(true);
+      } else {
+        // For other errors, show a toast notification
+        toast({
+          title: 'Error',
+          description: 'Failed to load News Hub. Please check your connection and try again.',
+          variant: 'destructive'
+        });
+      }
+      
       setInterestsLoaded(true);
     }
   };


### PR DESCRIPTION
Gracefully handle 404 errors in News Hub page to prevent error toasts for expected missing data.

The News Hub page previously displayed a "Request failed with status code 404" toast when a user had no interests or no articles, which is an expected state for new users. This PR updates the error handling to show the onboarding screen for missing user interests and suppresses error toasts for empty news feeds, improving the user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-70ab3af5-da44-4697-9b94-2760ee50f50e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-70ab3af5-da44-4697-9b94-2760ee50f50e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

