### PR TITLE
Fix news hub interest 404 error

### DIFF
--- a/src/frontend/src/services/newsHubService.ts
+++ b/src/frontend/src/services/newsHubService.ts
@@ -10,11 +10,11 @@ import type {
   ApiResponse
 } from '../types/newsHub';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api/v1';
 
 // Create axios instance with auth token
 const api = axios.create({
-  baseURL: `${API_BASE_URL}/api/v1/news-hub`,
+  baseURL: `${API_BASE_URL}/news-hub`,
   headers: {
     'Content-Type': 'application/json'
   }


### PR DESCRIPTION
Fix 404 error when adding news hub topics by removing duplicate `/api/v1` from the service base URL.

The `VITE_API_BASE_URL` environment variable already contains `/api/v1`. The `newsHubService` was appending another `/api/v1` to its `baseURL`, resulting in an incorrect path like `/api/v1/api/v1/news-hub/interests`. This change corrects the `baseURL` to avoid the duplication and ensures the correct API endpoint is hit. The localhost fallback for `API_BASE_URL` was also updated for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-b88e15cd-af1d-4ee2-bb6a-4c1701fc4a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b88e15cd-af1d-4ee2-bb6a-4c1701fc4a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

