### PR TITLE
Fix whatsapp image placeholder loading

### DIFF
--- a/src/frontend/src/components/common/SecureImage.tsx
+++ b/src/frontend/src/components/common/SecureImage.tsx
@@ -3,11 +3,20 @@ import { useSecureImage } from '../../hooks/useSecureImage';
 import { Loader2, AlertTriangle } from 'lucide-react';
 
 interface SecureImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
-  imageId: string | undefined;
+  imageId?: string;
+  messageId?: string;
+  source?: 'telegram' | 'whatsapp';
 }
 
-export const SecureImage: React.FC<SecureImageProps> = ({ imageId, className, alt, ...props }) => {
-  const { imageUrl, isLoading, error } = useSecureImage(imageId);
+export const SecureImage: React.FC<SecureImageProps> = ({ 
+  imageId, 
+  messageId, 
+  source = 'telegram',
+  className, 
+  alt, 
+  ...props 
+}) => {
+  const { imageUrl, isLoading, error } = useSecureImage({ imageId, messageId, source });
 
   if (isLoading) {
     return (

--- a/src/frontend/src/pages/ImagesPage.tsx
+++ b/src/frontend/src/pages/ImagesPage.tsx
@@ -399,17 +399,18 @@ const ImagesPage: React.FC = () => {
       return (
         <SecureImage 
           imageId={item.mediaGridFsId}
+          source="telegram"
           alt={item.aiAnalysis?.description || `Photo from ${item.fromUsername || 'Unknown'}`}
           className="w-full h-48 object-cover transition-transform duration-300 group-hover:scale-110"
         />
       );
-    } else if (item.source === 'whatsapp' && item.publicUrl) {
+    } else if (item.source === 'whatsapp' && item.messageId) {
       return (
-        <img 
-          src={item.publicUrl}
+        <SecureImage 
+          messageId={item.messageId}
+          source="whatsapp"
           alt={item.aiAnalysis?.description || `Photo from ${item.fromUsername || 'Unknown'}`}
           className="w-full h-48 object-cover transition-transform duration-300 group-hover:scale-110"
-          crossOrigin="use-credentials"
         />
       );
     } else {


### PR DESCRIPTION
Extend `SecureImage` to properly fetch and display WhatsApp images, resolving gray placeholders.

WhatsApp images were previously attempting to load directly via `publicUrl`, bypassing the secure fetching mechanism used by Telegram images. This resulted in gray placeholders until clicked. The `SecureImage` component and `useSecureImage` hook have been updated to handle WhatsApp images by fetching them from the correct authenticated API endpoint, ensuring immediate display with loading and error states.

---
<a href="https://cursor.com/background-agent?bcId=bc-d935cdf6-e391-44a7-92c3-b0b5fc20aa8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d935cdf6-e391-44a7-92c3-b0b5fc20aa8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

