### PR TITLE
Fix sidebar menu expansion on phones

### DIFF
--- a/src/frontend/src/components/layout/Sidebar.tsx
+++ b/src/frontend/src/components/layout/Sidebar.tsx
@@ -133,19 +133,18 @@ const Sidebar: React.FC<SidebarProps> = ({ isSidebarOpen }) => {
   return (
     <aside
       className={`
-        flex flex-col z-40
+        flex flex-col
         bg-gray-900 backdrop-blur-sm border-r border-white/10
         transition-all duration-300 ease-in-out
 
         /* DESKTOP (≥ md) ----------------------------------- */
-        hidden md:flex md:fixed md:top-[64px] md:left-0
+        hidden md:flex md:fixed md:top-[64px] md:left-0 md:z-40
         md:h-[calc(100vh-64px)] md:max-h-[calc(100vh-64px)] md:overflow-hidden
         ${isSidebarOpen ? "md:w-64" : "md:w-20"}
 
         /* MOBILE (< md) ------------------------------------ */
-        ${isSidebarOpen ? "flex" : "hidden"}
-        fixed top-[64px] left-0 h-[calc(100dvh-64px)]
-        ${isSidebarOpen ? "w-64 translate-x-0 shadow-2xl" : "w-20 -translate-x-full"}
+        fixed top-[64px] left-0 h-[calc(100dvh-64px)] w-64 z-50
+        ${isSidebarOpen ? "flex translate-x-0 shadow-2xl" : "hidden -translate-x-full"}
 
         /* Mobile optimizations for better clarity */
         md:bg-gray-900/95 md:backdrop-blur-md


### PR DESCRIPTION
Fix mobile sidebar expansion by resolving z-index conflict and adjusting visibility/transition classes.

The sidebar was not expanding on mobile devices because it had the same `z-index` (`z-40`) as the backdrop blur, causing it to be hidden behind the blur. This PR increases the mobile sidebar's `z-index` to `z-50` and updates the mobile visibility classes to correctly show/hide the sidebar with a translation effect.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f81c611-4990-404a-9db2-e5b45decf8ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f81c611-4990-404a-9db2-e5b45decf8ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

