### PR TITLE
fix(frontend): keep mobile header sticky

### DIFF
--- a/src/frontend/src/components/layout/Header.tsx
+++ b/src/frontend/src/components/layout/Header.tsx
@@ -50,8 +50,11 @@ const Header: React.FC<HeaderProps> = ({ isSidebarOpen, toggleSidebar }) => {
 
   return (
     <header
-      className="fixed top-0 left-0 right-0 z-50 w-full bg-black/40 md:bg-transparent border-b border-white/10 shadow-lg backdrop-blur-md pb-3 pr-4 md:pr-8 min-h-[64px] overflow-visible"
-      style={{ paddingTop: 'calc(env(safe-area-inset-top, 0px) + 0.75rem)' }}
+      className="sticky md:fixed top-0 left-0 right-0 z-50 w-full bg-black/40 md:bg-transparent border-b border-white/10 shadow-lg backdrop-blur-md pb-3 pr-4 md:pr-8 min-h-[64px] overflow-visible"
+      style={{
+        top: 'env(safe-area-inset-top, 0px)',
+        paddingTop: 'calc(env(safe-area-inset-top, 0px) + 0.75rem)'
+      }}
     >
       <div className="w-full pl-3 md:pl-6 flex items-center justify-between h-full max-w-none">
         <div className="flex items-center gap-2">

--- a/src/frontend/src/components/layout/Layout.tsx
+++ b/src/frontend/src/components/layout/Layout.tsx
@@ -92,7 +92,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
       <Header isSidebarOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />
 
-      <div className="flex relative pt-[64px]">
+      <div className="flex relative pt-0 md:pt-[64px]">
         {/* Enhanced scrim with blur effect */}
         <AnimatePresence>
           {isMobile && isSidebarOpen && (

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -834,18 +834,10 @@ code {
     min-width: 0;
   }
 
-  @media (max-width: 640px) {
-    /* Global mobile overflow prevention */
-    body, html, #root {
-      overflow-x: hidden !important;
-      max-width: 100vw !important;
-      width: 100% !important;
-    }
-
-    /* Ensure header stays fixed on mobile */
+  @media (max-width: 768px) {
     header {
-      position: fixed !important;
-      top: 0 !important;
+      position: sticky !important;
+      top: env(safe-area-inset-top, 0px) !important;
       left: 0 !important;
       right: 0 !important;
       width: 100% !important;
@@ -854,6 +846,15 @@ code {
       -webkit-transform: translateZ(0);
       backface-visibility: hidden;
       -webkit-backface-visibility: hidden;
+    }
+  }
+
+  @media (max-width: 640px) {
+    /* Global mobile overflow prevention */
+    body, html, #root {
+      overflow-x: hidden !important;
+      max-width: 100vw !important;
+      width: 100% !important;
     }
 
     /* Force all elements to respect viewport width */


### PR DESCRIPTION
## Summary
- ensure the shared header uses sticky positioning on small screens so the sidebar toggle remains visible
- update layout spacing and mobile CSS safe-area handling to keep content aligned under the persistent header

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5f6008a388331b206ef09b85fe011